### PR TITLE
Feat: add EPLB-based expert load balancing and layer-wise expert load status

### DIFF
--- a/dlblas/kernels/moe.py
+++ b/dlblas/kernels/moe.py
@@ -564,3 +564,70 @@ def biased_grouped_topk(
         topk_group,
         n_share_experts_fusion=n_share_experts_fusion,
     )
+
+@triton.jit
+def kernel_map_logic_to_physical_hash(
+    topk_idx_ptr,
+    physical_idx_ptr,
+    log2phy_ptr,
+    logcnt_ptr,
+    seed,
+    num_tokens,
+    num_topk,
+    num_logical_experts,
+    max_replica,
+    BLOCK: tl.constexpr
+):
+    pid = tl.program_id(0)
+    start_t = pid * BLOCK
+    end_t = tl.minimum(start_t + BLOCK, num_tokens)
+
+    for t in range(start_t, end_t):
+        row_off = t * num_topk
+        for k in range(num_topk):
+            logic_exp = tl.load(topk_idx_ptr + row_off + k)
+
+            # 条件判断不能用 continue，只能嵌套写
+            if logic_exp >= 0:
+                cnt = tl.load(logcnt_ptr + logic_exp)
+                if cnt > 0:
+                    # 构造 hash 值
+                    combined = ((t << 16) ^ (k << 8) ^ seed) & 0xFFFFFFFF
+                    x = combined
+                    x = ((x >> 16) ^ x) * 0x45d9f3b
+                    x = ((x >> 16) ^ x) * 0x45d9f3b
+                    x = (x >> 16) ^ x
+                    rand_val = x & 0x7fffffff
+
+                    replica_id = rand_val % cnt.to(tl.uint32)
+                    phy_id_addr = log2phy_ptr + logic_exp * max_replica + replica_id
+                    phy_id = tl.load(phy_id_addr)
+                    tl.store(physical_idx_ptr + row_off + k, phy_id)
+                else:
+                    tl.store(physical_idx_ptr + row_off + k, -1)
+            else:
+                tl.store(physical_idx_ptr + row_off + k, -1)
+
+
+def map_logic_to_physical_idx_hash_random(
+    topk_idx: torch.Tensor,
+    log2phy: torch.Tensor,
+    logcnt: torch.Tensor,
+    seed: int = 12345,
+    block_size: int = 128
+) -> torch.Tensor:
+    num_tokens, num_topk = topk_idx.shape
+    physical_idx = torch.empty_like(topk_idx, dtype=torch.int32, device=topk_idx.device)
+
+    grid = ((num_tokens + block_size - 1) // block_size,)
+
+    kernel_map_logic_to_physical_hash[grid](
+        topk_idx, physical_idx,
+        log2phy, logcnt,
+        seed,
+        num_tokens, num_topk,
+        log2phy.shape[0], log2phy.shape[1],
+        BLOCK=block_size
+    )
+
+    return physical_idx

--- a/dlblas/layers/moe/ep_moe.py
+++ b/dlblas/layers/moe/ep_moe.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2025, DeepLink.
-from typing import List
+from typing import List, Tuple
+import os
+enable_eplb = os.environ.get('EPLB_ENABLED', '0') == '1'
 
 import deep_gemm
 import torch
 import torch.distributed as dist
 
 from dlblas.kernels.moe import (grouped_gemm_triton, quant_fp8, renormalize, silu_and_mul_masked_post_quant_fwd,
-                                silu_and_mul_triton_kernel)
+                                silu_and_mul_triton_kernel, map_logic_to_physical_idx_hash_random)
 from dlblas.layers.moe.token_dispatcher import DeepEPTokenDispatcherLowLatency, TokenDispatcherBuilder
 from dlblas.utils.logger import get_logger
 
@@ -182,8 +184,10 @@ class FusedMoENormal:
                  ep_group: dist.ProcessGroup,
                  num_experts: int,
                  hidden_dim: int,
+                 layer_index: int,
                  block_size: int = 128,
                  out_dtype: torch.dtype = torch.bfloat16):
+        self.layer_index = layer_index
         self.experts = DeepEPExpertsGroupedGEMM(num_experts, ep_size, [block_size, block_size])
         self.token_dispatcher = TokenDispatcherBuilder.build(
             group=ep_group,
@@ -191,7 +195,140 @@ class FusedMoENormal:
             num_local_experts=num_experts // ep_size,
             hidden_size=hidden_dim,
             params_dtype=out_dtype,
+            layer_index=layer_index,
         )
+    def balanced_packing(self, weight: torch.Tensor, num_packs: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        
+        num_layers, num_groups = weight.shape
+        assert num_groups % num_packs == 0
+        groups_per_pack = num_groups // num_packs
+
+        if groups_per_pack == 1:
+            pack_index = torch.arange(weight.size(-1), dtype=torch.int64, device=weight.device).expand(weight.shape)
+            rank_in_pack = torch.zeros_like(weight, dtype=torch.int64)
+            return pack_index, rank_in_pack
+
+        indices = weight.float().sort(-1, descending=True).indices.cpu()
+        pack_index = torch.full_like(weight, fill_value=-1, dtype=torch.int64, device='cpu')
+        rank_in_pack = torch.full_like(pack_index, fill_value=-1)
+        for i in range(num_layers):
+            pack_weights = [0] * num_packs
+            pack_items = [0] * num_packs
+            for group in indices[i]:
+                pack = min((i for i in range(num_packs) if pack_items[i] < groups_per_pack), 
+                        key=pack_weights.__getitem__)
+                assert pack_items[pack] < groups_per_pack
+                pack_index[i, group] = pack
+                rank_in_pack[i, group] = pack_items[pack]
+                pack_weights[pack] += weight[i, group]
+                pack_items[pack] += 1
+        return pack_index, rank_in_pack
+
+
+    def replicate_experts(self, weight: torch.Tensor, num_phy: int) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+
+        n, num_log = weight.shape
+        num_redundant = num_phy - num_log
+        assert num_redundant >= 0
+        device = weight.device
+        phy2log = torch.arange(num_phy, dtype=torch.int64, device=device).repeat(n, 1)
+        rank = torch.zeros(n, num_phy, dtype=torch.int64, device=device)
+        logcnt = torch.ones(n, num_log, dtype=torch.int64, device=device)
+        arangen = torch.arange(n, dtype=torch.int64, device=device)
+        for i in range(num_log, num_phy):
+            redundant_indices = (weight / logcnt).max(dim=-1).indices
+            phy2log[:, i] = redundant_indices
+            rank[:, i] = logcnt[arangen, redundant_indices]
+            logcnt[arangen, redundant_indices] += 1
+        return phy2log, rank, logcnt
+
+
+    def rebalance_experts_hierarchical(self, weight: torch.Tensor, num_physical_experts: int, num_groups: int, num_nodes: int, num_gpus: int):
+
+        num_layers, num_logical_experts = weight.shape
+        assert num_logical_experts % num_groups == 0
+        group_size = num_logical_experts // num_groups 
+        assert num_groups % num_nodes == 0
+        groups_per_node = num_groups // num_nodes
+        assert num_gpus % num_nodes == 0
+        assert num_physical_experts % num_gpus == 0
+        phy_experts_per_gpu = num_physical_experts // num_gpus
+
+        def inverse(perm: torch.Tensor) -> torch.Tensor:
+            inv = torch.empty_like(perm)
+            inv.scatter_(1, perm, torch.arange(perm.size(1), dtype=torch.int64, device=perm.device).expand(perm.shape))
+            return inv
+
+        tokens_per_group = weight.unflatten(-1, (num_groups, group_size)).sum(-1)
+        group_pack_index, group_rank_in_pack = self.balanced_packing(tokens_per_group, num_nodes) 
+        log2mlog = (((group_pack_index * groups_per_node + group_rank_in_pack) * group_size).unsqueeze(-1) + 
+                    torch.arange(group_size, dtype=torch.int64, device=group_pack_index.device)).flatten(-2)
+        mlog2log = inverse(log2mlog)
+        tokens_per_mlog = weight.gather(-1, mlog2log).view(-1, num_logical_experts // num_nodes)
+        phy2mlog, phyrank, mlogcnt = self.replicate_experts(tokens_per_mlog, num_physical_experts // num_nodes)  
+        tokens_per_phy = (tokens_per_mlog / mlogcnt).gather(-1, phy2mlog)
+        pack_index, rank_in_pack = self.balanced_packing(tokens_per_phy, num_gpus // num_nodes)
+        phy2pphy = pack_index * phy_experts_per_gpu + rank_in_pack
+        pphy2phy = inverse(phy2pphy)
+        pphy2mlog = phy2mlog.gather(-1, pphy2phy) # [num_layers * num_nodes, num_log_per_nodes]
+        pphy2mlog = (pphy2mlog.view(num_layers, num_nodes, -1) + 
+                    torch.arange(0, num_logical_experts, num_logical_experts // num_nodes).view(1, -1, 1)).flatten(-2)
+        pphy2log = mlog2log.gather(-1, pphy2mlog)
+        pphyrank = phyrank.gather(-1, pphy2phy).view(num_layers, -1)
+        logcnt = mlogcnt.view(num_layers, -1).gather(-1, log2mlog)
+        return pphy2log, pphyrank, logcnt
+
+    def rebalance_experts(self, weight: torch.Tensor, num_replicas: int, num_groups: int,
+                        num_nodes: int, num_gpus: int) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        
+        num_layers, num_logical_experts = weight.shape
+        weight = weight.float().cpu()
+        if num_groups % num_nodes == 0:
+            # use hierarchical load-balance policy
+            phy2log, phyrank, logcnt = self.rebalance_experts_hierarchical(weight, num_replicas, 
+                                                                    num_groups, num_nodes, num_gpus)
+        else:
+            # use global load-balance policy
+            phy2log, phyrank, logcnt = self.replicate_experts(weight, num_replicas)
+        maxlogcnt = logcnt.max().item()
+        log2phy: torch.Tensor = torch.full((num_layers, num_logical_experts, maxlogcnt), 
+                                        -1, dtype=torch.int64, device=logcnt.device)
+        log2phy.view(num_layers, -1).scatter_(-1, phy2log * maxlogcnt + phyrank, 
+                torch.arange(num_replicas, dtype=torch.int64, device=log2phy.device).expand(num_layers, -1))
+        return phy2log, log2phy, logcnt
+    
+    def ep_expert_list(self, world_size: int, rank: int, num_groups: int=None, num_nodes: int=None, weight: torch.Tensor=None):
+        """experts list of current rank."""
+        if enable_eplb:
+            self.num_groups = num_groups
+            self.num_nodes = num_nodes
+            self.num_gpus = world_size
+            # 调用 rebalance_experts 函数获取映射信息
+            phy2log, log2phy, logcnt = self.rebalance_experts(weight, self.num_experts, self.num_groups, self.num_nodes, self.num_gpus)
+            self.phy2log = phy2log[0].to('cuda')
+            self.log2phy = log2phy[0].to('cuda')
+            self.logcnt = logcnt[0].to('cuda')
+            # 计算每个 rank 对应的专家数量
+            expert_per_rank = (self.num_experts + world_size - 1) // world_size
+            first_expert = rank * expert_per_rank
+            last_expert = min(first_expert + expert_per_rank, self.num_experts)
+            # if(rank == 0):
+            # print("first_expert = ", first_expert)
+            # print("last_expert = ", last_expert)
+
+            # 获取 phy2log 的切片数据
+            sliced_phy2log = self.phy2log[first_expert:last_expert].tolist()
+            # if(rank == 0):
+            # print("sliced_phy2log = ", sliced_phy2log)
+
+            return sliced_phy2log
+        else:
+            num_experts = self.num_experts
+            expert_per_rank = (num_experts + world_size - 1) // world_size
+            first_expert = rank * expert_per_rank
+            last_expert = min(first_expert + expert_per_rank, num_experts)
+            return list(range(first_expert, last_expert))
+
 
     def forward(self,
                 hidden_states: torch.Tensor,
@@ -203,6 +340,10 @@ class FusedMoENormal:
                 down_scale: torch.Tensor,
                 expert_list: List[int] = None):
         """forward."""
+        if enable_eplb:
+            topk_ids = map_logic_to_physical_idx_hash_random(topk_ids, self.log2phy, self.logcnt)
+        else:
+            topk_ids = topk_ids
         recv_hidden_states, recv_topk_ids, recv_topk_weights, tokens_per_expert = self.token_dispatcher.dispatch(
             hidden_states,
             topk_ids,
@@ -262,6 +403,7 @@ class FusedMoEBlockedF8Impl:
                  ep_size: int,
                  ep_group: dist.ProcessGroup,
                  top_k: int,
+                 layer_index: int,
                  num_experts: int,
                  hidden_dim: int,
                  renormalize: bool = False,
@@ -271,6 +413,7 @@ class FusedMoEBlockedF8Impl:
         self.ep_size = ep_size
         self.ep_group = ep_group
         self.top_k = top_k
+        self.layer_index = layer_index
         self.hidden_dim = hidden_dim
         self.renormalize = renormalize
         self.block_size = block_size
@@ -290,7 +433,7 @@ class FusedMoEBlockedF8Impl:
         topk_weights = renormalize(topk_weights, self.renormalize)
         moe = None
         if is_decoding is False:
-            moe = FusedMoENormal(self.ep_size, self.ep_group, self.num_experts, self.hidden_dim, self.block_size,
+            moe = FusedMoENormal(self.ep_size, self.ep_group, self.num_experts, self.hidden_dim, self.layer_index, self.block_size,
                                  self.out_dtype)
         else:
             moe = FusedMoELowLatency(self.ep_size, self.ep_group, self.num_experts, self.hidden_dim, self.block_size,

--- a/dlblas/utils/moe_utils.py
+++ b/dlblas/utils/moe_utils.py
@@ -1,0 +1,24 @@
+
+from collections import defaultdict
+
+# 模块级别的单例
+global_tokens_per_expert = defaultdict(list)
+# print(f"global_tokens_per_expert id in utils: {id(global_tokens_per_expert)}")
+
+def save_expert_stats_to_file(rank: int, filepath: str = None):
+    # print(f"global_tokens_per_expert id in utils: {id(global_tokens_per_expert)}")
+    import os, json
+    if filepath is None:
+        filepath = f"/tmp/expert_load_rank{rank}.json"
+    else:
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+
+    stats_summary = {}
+    for layer, stats in global_tokens_per_expert.items():
+        if stats:
+            total = torch.stack(stats).sum(dim=0).tolist()
+            stats_summary[f"layer_{layer}"] = total
+
+    with open(filepath, 'w') as f:
+        json.dump(stats_summary, f, indent=2)
+    print(f"[Rank {rank}] Expert stats saved to {filepath}")


### PR DESCRIPTION
## Motivation

This pull request introduces:

- Initial integration of Expert Placement Load Balancing (EPLB) in the lmdeploy MoE framework, to support logical-to-physical expert index remapping per rank.
- Layer-wise expert token load statistics, useful for analyzing token distribution across experts during inference.

## Modification

1. EPLB Support (Preliminary)

- Environment Variable Control: Added EPLB_ENABLED=1 to enable EPLB mode.
- Expert List Generation: Enhanced ep_expert_list() in moe.py to support num_groups, num_nodes, and external expert mapping weights (e.g., from a JSON file).
- Token Dispatch: In FusedDeepEpMoEBlockedF8Impl, logical expert indices are remapped to physical ones using map_logic_to_physical_idx_hash_random when EPLB is enabled.

2. Layer-wise Expert Load Statistics
- Environment Variable: MOE_LOAD_STATS=1 enables token count logging per expert per layer.
- Token Dispatcher: Modified DeepEPTokenDispatcherNormal.dispatch() to record per-dispatch expert loads and periodically export to JSON.

## Important Notes

This implementation is currently in draft status and has only been validated in a 4-GPU setting. The following limitations apply:

- Only tested in a single-node 4-GPU setup.
- All layers share the same expert map (log2phy).
- EPLB and stats logging are fully opt-in and backward-compatible.

## BC-breaking

No.
All changes are backward-compatible and only activated when EPLB_ENABLED=1 is set in the environment.

## Checklist

- [x] EPLB logic integrated and validated in 4-GPU setting.
- [x] Expert statistics exported layer-wise when MOE_LOAD_STATS=1.
- [ ] Expert-to-rank mapping is identical across all MoE layers, which may limit flexibility.
- [ ] Multi-node support is not tested; current design assumes a single-node environment.
- [ ] Dynamic expert remapping during runtime is not yet implemented.

