### PR TITLE
refactor(moe): relocate load stats tracking into FusedMoELowLatency and FusedMoENormal classes

### DIFF
--- a/dlblas/layers/moe/ep_moe.py
+++ b/dlblas/layers/moe/ep_moe.py
@@ -15,6 +15,7 @@ from dlblas.utils.logger import get_logger
 
 logger = get_logger(__name__)
 enable_eplb = os.environ.get('EPLB_ENABLED', '0') == '1'
+enable_moe_load_stats = os.environ.get('MOE_LOAD_STATS', '0') == '1'
 
 
 class FusedExperts:
@@ -321,6 +322,49 @@ class FusedMoENormal:
         expert_list: List[int] = None,
     ):
         """forward."""
+        if enable_moe_load_stats:
+            global normal_dispatch_count
+            normal_dispatch_count += 1
+            num_global_experts = self.num_experts
+            topk_ids_flat = topk_ids.view(-1)
+            step_local_counts = torch.bincount(
+                topk_ids_flat,
+                minlength=num_global_experts
+            )
+
+            global normal_accum_global_token_counts
+            if normal_accum_global_token_counts is None:
+                normal_accum_global_token_counts = torch.zeros(num_global_experts, dtype=torch.int64, device="cuda")
+
+            normal_accum_global_token_counts += step_local_counts
+
+            if normal_dispatch_count % 100 == 0:
+                global_token_counts = normal_accum_global_token_counts.clone()
+                if dist.is_initialized():
+                    dist.all_reduce(global_token_counts, op=dist.ReduceOp.SUM)
+
+                global_list = global_token_counts.cpu().tolist()
+
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                if True:
+                    output_dir = os.path.join(
+                        os.path.dirname(__file__),
+                        '../../../my_output/prefill_moe_stats'
+                    )
+                    os.makedirs(output_dir, exist_ok=True)
+
+                    filepath = os.path.join(
+                        output_dir,
+                        f"rank{rank}_layer{self.layer_index}_step{normal_dispatch_count}_global_token_counts.json"
+                    )
+                    with open(filepath, 'w') as f:
+                        import json
+                        json.dump(global_list, f, indent=2)
+
+                    print(f"[Global] Layer rank{rank} {self.layer_index} step {normal_dispatch_count}")
+                    print(f"rank{rank} → Accumulated global expert token counts: {global_list}")
+
+
         if enable_eplb:
             topk_ids = map_logic_to_physical_idx_hash_random(topk_ids, self.log2phy, self.logcnt)
         else:
@@ -376,9 +420,11 @@ class FusedMoELowLatency:
                  ep_group: dist.ProcessGroup,
                  num_experts: int,
                  hidden_dim: int,
+                 layer_index: int,
                  block_size: int = 128,
                  out_dtype: torch.dtype = torch.bfloat16):
         self.num_experts = num_experts
+        self.layer_index = layer_index
         self.experts = DeepEPExpertsDeepGEMM(num_experts, ep_size, block_size, out_dtype)
         self.token_dispatcher = DeepEPTokenDispatcherLowLatency(
             group=ep_group,
@@ -398,6 +444,47 @@ class FusedMoELowLatency:
                 down_scale: torch.Tensor,
                 expert_list: List[int] = None):
         """forward."""
+        if enable_moe_load_stats:
+            global ll_dispatch_count
+            ll_dispatch_count += 1
+            num_global_experts = self.num_experts
+            topk_ids_flat = topk_ids.view(-1)
+            step_local_counts = torch.bincount(
+                topk_ids_flat,
+                minlength=num_global_experts
+            )
+
+            global ll_accum_global_token_counts
+            if ll_accum_global_token_counts is None:
+                ll_accum_global_token_counts = torch.zeros(num_global_experts, dtype=torch.int64, device="cuda")
+
+            ll_accum_global_token_counts += step_local_counts
+
+            if ll_dispatch_count % 200 == 0:
+                global_token_counts = ll_accum_global_token_counts.clone()
+                if dist.is_initialized():
+                    dist.all_reduce(global_token_counts, op=dist.ReduceOp.SUM)
+
+                global_list = global_token_counts.cpu().tolist()
+
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                if True:
+                    output_dir = os.path.join(
+                        os.path.dirname(__file__),
+                        '../../../my_output/decode_moe_stats'
+                    )
+                    os.makedirs(output_dir, exist_ok=True)
+
+                    filepath = os.path.join(
+                        output_dir,
+                        f"rank{rank}_layer{self.layer_index}_step{ll_dispatch_count}_global_token_counts.json"
+                    )
+                    with open(filepath, 'w') as f:
+                        import json
+                        json.dump(global_list, f, indent=2)
+
+                    print(f"[Global] rank{rank} Layer {self.layer_index} step {ll_dispatch_count}")
+                    print(f"rank{rank}→ Accumulated global expert token counts: {global_list}")
         recv_hidden_states, topk_idx, topk_weights, masked_m, expected_m = self.token_dispatcher.dispatch(
             hidden_states,
             topk_ids,
@@ -474,6 +561,7 @@ def build_deepep_moe(low_latency_mode: bool,
                      hidden_dim: int,
                      block_size: int,
                      top_k: int,
+                     layer_index: int,
                      out_dtype: torch.dtype,
                      chunk_size: Optional[int] = 32 * 1024):
     if low_latency_mode:
@@ -481,6 +569,7 @@ def build_deepep_moe(low_latency_mode: bool,
                                   ep_group=ep_group,
                                   num_experts=num_experts,
                                   hidden_dim=hidden_dim,
+                                  layer_index=layer_index,
                                   block_size=block_size,
                                   out_dtype=out_dtype)
     else:
@@ -488,6 +577,7 @@ def build_deepep_moe(low_latency_mode: bool,
                               ep_group=ep_group,
                               num_experts=num_experts,
                               hidden_dim=hidden_dim,
+                              layer_index=layer_index,
                               block_size=block_size,
                               top_k=top_k,
                               out_dtype=out_dtype,


### PR DESCRIPTION
**Summary:**
- Moved the MoE load stats recording logic into the FusedMoELowLatency and FusedMoENormal classes for better code modularity.
- Previously scattered code is now centralized inside the respective classes' dispatch process.
- No changes to the load stats calculation logic; only the code organization is improved.
This refactor improves maintainability and readability, and lays groundwork for future enhancements to MoE dispatch tracking.

**Related files:**
- dlblas/layers/moe/ep_moe.py

**How to Enable Expert Load Stats:**

To enable expert load statistics, simply set the following environment variable:
`export expert_enable_moe_load_stats=1`
Once enabled, the system will start recording and tracking expert load statistics during MoE dispatch.