### PR TITLE
Add grpo_compute_loss_logits.py to support different GRPO_LOSS function parameters 

### DIFF
--- a/benchmarks/grpo.py
+++ b/benchmarks/grpo.py
@@ -1,0 +1,78 @@
+# benchmark_grpo.py
+
+import torch
+import triton
+from dlblas.kernel.grpo_compute_loss_logits import grpo_compute_loss_torch, grpo_loss_triton
+
+def run_benchmark(BL, V, dtype):
+    """
+    运行给定 shape 和 dtype 的基准测试。
+    
+    参数:
+    BL (int): 总 token 数 (Batch Size * Sequence Length)
+    V (int): 词汇表大小
+    dtype (torch.dtype): 数据类型 (通常是 torch.float16)
+    """
+    print("-" * 60)
+    print(f"Benchmarking with BL={BL}, V={V}, dtype={dtype}")
+    print("-" * 60)
+    
+    new_logits = torch.randn((BL, V), device='cuda', dtype=dtype).contiguous()
+    ref_logits = torch.randn((BL, V), device='cuda', dtype=dtype).contiguous()
+    old_logits = torch.randn((BL, V), device='cuda', dtype=dtype).contiguous()
+    input_ids = torch.randint(0, V, (BL,), device='cuda').contiguous()
+    advantages = torch.randn((BL,), device='cuda', dtype=dtype).contiguous()
+    mask = torch.randint(0, 2, (BL,), device='cuda').bool().contiguous()
+
+    
+    kwargs = {
+        'beta': 0.1,
+        'loss_type': 'grpo',
+        'epsilon_low': 0.2,
+        'epsilon_high': 0.2,
+        'delta': 5.0,
+        'temperature': 1.0,
+    }
+
+  
+    # PyTorch 基准测试
+    torch_ms = triton.testing.do_bench(
+        lambda: grpo_compute_loss_torch(
+            new_logits, ref_logits, old_logits, input_ids, advantages, mask, **kwargs
+        )
+    )
+
+    # Triton 基准测试
+    triton_ms = triton.testing.do_bench(
+        lambda: grpo_loss_triton(
+            new_logits, ref_logits, old_logits, input_ids, advantages, mask, **kwargs
+        )
+    )
+
+    # 3. 打印结果
+    speedup = torch_ms / triton_ms
+    print(f"PyTorch implementation: {torch_ms:.4f} ms")
+    print(f"Triton implementation:  {triton_ms:.4f} ms")
+    print(f"Speedup: {speedup:.2f}x")
+    print("\n")
+
+
+if __name__ == '__main__':
+    if not torch.cuda.is_available():
+        print("CUDA not available. Skipping benchmark.")
+        exit()
+
+  
+    benchmark_configs = [
+      # 场景 1: V = 32768 (2^15)
+        (8 * 2048, 32768),  # 典型训练 (BL=16384)
+        (2048, 32768),  # 极长上下文 (BL=32768)
+
+        # 场景 2: V = 65536 (2^16)
+        (1* 2048, 65536),   # 典型训练 (BL=16384)
+       
+    ]
+
+    for bl, v in benchmark_configs:
+        
+        run_benchmark(BL=bl, V=v, dtype=torch.float16)

--- a/dlblas/kernels/grpo_compute_loss_logits.py
+++ b/dlblas/kernels/grpo_compute_loss_logits.py
@@ -9,34 +9,72 @@ import triton
 import triton.language as tl
 #reference:  https://github.com/unslothai/unsloth-zoo/blob/main/unsloth_zoo/rl_replacements.py
 @triton.jit
-def grpo_loss_kernel(
+def grpo_loss_triton_kernel(
     # 输入指针
     new_logits_ptr, ref_logits_ptr, old_logits_ptr,
     input_ids_ptr, advantages_ptr, mask_ptr,
-    # 预计算的 logsumexp 指针
-    lse_new_ptr, lse_ref_ptr, lse_old_ptr,
     # 输出指针
     loss_ptr, kl_ptr,
     # 常量参数
-    BL: tl.constexpr,
-    V: tl.constexpr,  # [MODIFIED] V 必须作为 constexpr 显式传入
-    BLOCK_M: tl.constexpr,
+    BL: tl.constexpr, V: tl.constexpr,
+    BLOCK_M: tl.constexpr, BLOCK_V: tl.constexpr,
     beta: tl.constexpr, delta: tl.constexpr,
     epsilon_low: tl.constexpr, epsilon_high: tl.constexpr,
     TEMPERATURE: tl.constexpr,
 ):
     pid = tl.program_id(0)
     row0 = pid * BLOCK_M
-    offs_t = row0 + tl.arange(0, BLOCK_M)
-    m_t = offs_t < BL
+    offs_t = row0 + tl.arange(0, BLOCK_M)  # [BLOCK_M], 负责的行索引
+    m_t = offs_t < BL  # [BLOCK_M], 行掩码
+
+ 
+    m_new, m_ref, m_old = tl.full([BLOCK_M], -float('inf'), dtype=tl.float32), tl.full([BLOCK_M], -float('inf'), dtype=tl.float32), tl.full([BLOCK_M], -float('inf'), dtype=tl.float32)
+    s_new, s_ref, s_old = tl.zeros([BLOCK_M], dtype=tl.float32), tl.zeros([BLOCK_M], dtype=tl.float32), tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    # 内部循环，分块处理每一行
+    for v_start in range(0, V, BLOCK_V):
+        # 计算当前块的列偏移量
+        v_offs = v_start + tl.arange(0, BLOCK_V)  # [BLOCK_V]
+        v_mask = v_offs < V  # [BLOCK_V], 列掩码
+
+        # --- 为 new_logits 更新 logsumexp ---
+        # 加载一个 logits 块: [BLOCK_M, BLOCK_V]
+        new_chunk = tl.load(new_logits_ptr + offs_t[:, None] * V + v_offs[None, :], mask=m_t[:, None] & v_mask[None, :], other=-float('inf'))
+        if TEMPERATURE != 1.0: new_chunk /= TEMPERATURE
+        
+        # 在块内找到最大值
+        chunk_m_new = tl.max(new_chunk, axis=1)
+        # 更新全局最大值
+        new_m_new = tl.maximum(m_new, chunk_m_new)
+        # 更新 sum (这是数值稳定的关键步骤)
+        s_new = s_new * tl.exp(m_new - new_m_new) + tl.sum(tl.exp(new_chunk - new_m_new[:, None]), axis=1)
+        m_new = new_m_new
+
+        # --- 为 ref_logits 更新 logsumexp ---
+        ref_chunk = tl.load(ref_logits_ptr + offs_t[:, None] * V + v_offs[None, :], mask=m_t[:, None] & v_mask[None, :], other=-float('inf'))
+        if TEMPERATURE != 1.0: ref_chunk /= TEMPERATURE
+        chunk_m_ref = tl.max(ref_chunk, axis=1)
+        new_m_ref = tl.maximum(m_ref, chunk_m_ref)
+        s_ref = s_ref * tl.exp(m_ref - new_m_ref) + tl.sum(tl.exp(ref_chunk - new_m_ref[:, None]), axis=1)
+        m_ref = new_m_ref
+
+        # --- 为 old_logits 更新 logsumexp ---
+        old_chunk = tl.load(old_logits_ptr + offs_t[:, None] * V + v_offs[None, :], mask=m_t[:, None] & v_mask[None, :], other=-float('inf'))
+        if TEMPERATURE != 1.0: old_chunk /= TEMPERATURE
+        chunk_m_old = tl.max(old_chunk, axis=1)
+        new_m_old = tl.maximum(m_old, chunk_m_old)
+        s_old = s_old * tl.exp(m_old - new_m_old) + tl.sum(tl.exp(old_chunk - new_m_old[:, None]), axis=1)
+        m_old = new_m_old
+
+    # 循环结束后，完成 logsumexp 的计算
+    lse_new = m_new + tl.log(s_new)
+    lse_ref = m_ref + tl.log(s_ref)
+    lse_old = m_old + tl.log(s_old)
+
 
     ids = tl.load(input_ids_ptr + offs_t, mask=m_t, other=0)
     ids = tl.where(ids >= 0, ids, 0)
 
-    # [REMOVED] 不再从指针推断 V，因为它不可靠
-    # V = new_logits_ptr.shape[1]
-
-    # 只加载目标 token 的 logit
     new_x = tl.load(new_logits_ptr + offs_t * V + ids, mask=m_t, other=-float('inf'))
     ref_x = tl.load(ref_logits_ptr + offs_t * V + ids, mask=m_t, other=-float('inf'))
     old_x = tl.load(old_logits_ptr + offs_t * V + ids, mask=m_t, other=-float('inf'))
@@ -45,12 +83,6 @@ def grpo_loss_kernel(
         inv_temp = 1.0 / TEMPERATURE
         new_x, ref_x, old_x = new_x * inv_temp, ref_x * inv_temp, old_x * inv_temp
 
-    # 直接加载预先计算好的 logsumexp 值
-    lse_new = tl.load(lse_new_ptr + offs_t, mask=m_t, other=0.0)
-    lse_ref = tl.load(lse_ref_ptr + offs_t, mask=m_t, other=0.0)
-    lse_old = tl.load(lse_old_ptr + offs_t, mask=m_t, other=0.0)
-
-    # 后续逻辑保持不变
     new_lp, ref_lp, old_lp = new_x - lse_new, ref_x - lse_ref, old_x - lse_old
 
     tmp_kl = tl.exp(ref_lp - new_lp) - (ref_lp - new_lp) - 1.0
@@ -79,23 +111,67 @@ def grpo_loss_kernel(
     tl.store(kl_ptr + offs_t, kl_i_masked, mask=m_t)
 
 
+def grpo_loss_triton(
+    new_logits, ref_logits, old_logits, input_ids, advantages, mask,
+    beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
+    max_completion_length=8192, delta=None, temperature=1.0,
+):
+    BL, V = new_logits.shape
+    
+    # 定义块大小
+    BLOCK_M = 64  
+    BLOCK_V = 2048 
+    
+    grid = ((BL + BLOCK_M - 1) // BLOCK_M, )
+    
+    loss_i = torch.empty(BL, device=new_logits.device, dtype=torch.float32)
+    kl_i = torch.empty(BL, device=new_logits.device, dtype=torch.float32)
+
+    delta_kernel = delta if delta is not None else -1.0
+
+    grpo_loss_triton_kernel[grid](
+        new_logits, ref_logits, old_logits, input_ids, advantages, mask,
+        loss_i, kl_i,
+        BL=BL, V=V,
+        BLOCK_M=BLOCK_M, BLOCK_V=BLOCK_V,
+        beta=beta, epsilon_low=epsilon_low, epsilon_high=epsilon_high, delta=delta_kernel,
+        TEMPERATURE=temperature,
+    )
+
+    # 后续的聚合逻辑与之前相同
+    mask_float = mask.to(torch.float32)
+    if loss_type == "grpo" or loss_type == "bnpo":
+        loss_aggregated = loss_i.sum() / mask_float.sum().clamp(min=1.0)
+    elif loss_type == "dr_grpo":
+        loss_aggregated = loss_i.sum() / (loss_i.size(0) * max_completion_length)
+    else:
+        raise ValueError(f"Unknown loss type: {loss_type}")
+
+    with torch.inference_mode():
+        completion_length = mask_float.sum()
+        mean_kl = kl_i.sum() / mask_float.sum().clamp(min=1.0)
+
+    return loss_aggregated, completion_length, mean_kl, loss_i, kl_i
+
+
+
 def grpo_compute_loss_torch(
     new_logits, ref_logits, old_logits, input_ids, advantages, mask,
     beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
     max_completion_length=8192, delta=None, temperature=1.0,
 ):
-    # PyTorch 参考实现保持不变
-    new_logits, ref_logits, old_logits = new_logits.to(torch.float32), ref_logits.to(torch.float32), old_logits.to(torch.float32)
+   
+    new_logits_fp32, ref_logits_fp32, old_logits_fp32 = new_logits.to(torch.float32), ref_logits.to(torch.float32), old_logits.to(torch.float32)
 
     if temperature != 1.0:
-        new_logits, ref_logits, old_logits = new_logits / temperature, ref_logits / temperature, old_logits / temperature
+        new_logits_fp32, ref_logits_fp32, old_logits_fp32 = new_logits_fp32 / temperature, ref_logits_fp32 / temperature, old_logits_fp32 / temperature
 
     input_ids_expanded = input_ids.unsqueeze(-1)
-    new_x = torch.gather(new_logits, dim=-1, index=input_ids_expanded).squeeze(-1)
-    ref_x = torch.gather(ref_logits, dim=-1, index=input_ids_expanded).squeeze(-1)
-    old_x = torch.gather(old_logits, dim=-1, index=input_ids_expanded).squeeze(-1)
+    new_x = torch.gather(new_logits_fp32, dim=-1, index=input_ids_expanded).squeeze(-1)
+    ref_x = torch.gather(ref_logits_fp32, dim=-1, index=input_ids_expanded).squeeze(-1)
+    old_x = torch.gather(old_logits_fp32, dim=-1, index=input_ids_expanded).squeeze(-1)
 
-    lse_new, lse_ref, lse_old = torch.logsumexp(new_logits, dim=-1), torch.logsumexp(ref_logits, dim=-1), torch.logsumexp(old_logits, dim=-1)
+    lse_new, lse_ref, lse_old = torch.logsumexp(new_logits_fp32, dim=-1), torch.logsumexp(ref_logits_fp32, dim=-1), torch.logsumexp(old_logits_fp32, dim=-1)
     new_lp, ref_lp, old_lp = new_x - lse_new, ref_x - lse_ref, old_x - lse_old
 
     kl_i = torch.exp(ref_lp - new_lp) - (ref_lp - new_lp) - 1.0 if beta != 0.0 else torch.zeros_like(ref_lp)
@@ -114,8 +190,6 @@ def grpo_compute_loss_torch(
     
     if loss_type == "grpo" or loss_type == "bnpo":
         loss = masked_loss_i.sum() / mask_float.sum().clamp(min=1.0)
-    elif loss_type == "dr_grpo":
-        loss = masked_loss_i.sum() / (loss_i.size(0) * max_completion_length)
     else:
         raise ValueError(f"Unknown loss type: {loss_type}")
 
@@ -124,55 +198,3 @@ def grpo_compute_loss_torch(
         mean_kl = (kl_i * mask_float).sum() / mask_float.sum().clamp(min=1.0)
 
     return loss, completion_length, mean_kl, masked_loss_i, kl_i * mask_float
-
-
-def grpo_loss_triton(
-    new_logits, ref_logits, old_logits, input_ids, advantages, mask,
-    beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
-    max_completion_length=8192, delta=None, temperature=1.0,
-):
-    BL, V = new_logits.shape
-    BLOCK_M = 64
-    grid = ((BL + BLOCK_M - 1) // BLOCK_M, )
-    
-    loss_i = torch.empty(BL, device=new_logits.device, dtype=torch.float32)
-    kl_i = torch.empty(BL, device=new_logits.device, dtype=torch.float32)
-
-    delta_kernel = delta if delta is not None else -1.0
-
-    # 预计算 logsumexp
-    new_logits_scaled = new_logits.to(torch.float32)
-    ref_logits_scaled = ref_logits.to(torch.float32)
-    old_logits_scaled = old_logits.to(torch.float32)
-    
-    if temperature != 1.0:
-        new_logits_scaled, ref_logits_scaled, old_logits_scaled = new_logits_scaled / temperature, ref_logits_scaled / temperature, old_logits_scaled / temperature
-    
-    lse_new = torch.logsumexp(new_logits_scaled, dim=-1)
-    lse_ref = torch.logsumexp(ref_logits_scaled, dim=-1)
-    lse_old = torch.logsumexp(old_logits_scaled, dim=-1)
-
-    grpo_loss_kernel[grid](
-        new_logits, ref_logits, old_logits, input_ids, advantages, mask,
-        lse_new, lse_ref, lse_old,
-        loss_i, kl_i,
-        BL=BL,
-        V=V,  # [MODIFIED] 将 V 显式传入内核
-        BLOCK_M=BLOCK_M,
-        beta=beta, epsilon_low=epsilon_low, epsilon_high=epsilon_high, delta=delta_kernel,
-        TEMPERATURE=temperature,
-    )
-
-    mask_float = mask.to(torch.float32)
-    if loss_type == "grpo" or loss_type == "bnpo":
-        loss_aggregated = loss_i.sum() / mask_float.sum().clamp(min=1.0)
-    elif loss_type == "dr_grpo":
-        loss_aggregated = loss_i.sum() / (loss_i.size(0) * max_completion_length)
-    else:
-        raise ValueError(f"Unknown loss type: {loss_type}")
-
-    with torch.inference_mode():
-        completion_length = mask_float.sum()
-        mean_kl = kl_i.sum() / mask_float.sum().clamp(min=1.0)
-
-    return loss_aggregated, completion_length, mean_kl, loss_i, kl_i

--- a/dlblas/kernels/grpo_compute_loss_logits.py
+++ b/dlblas/kernels/grpo_compute_loss_logits.py
@@ -1,0 +1,177 @@
+import torch
+import triton
+import triton.language as tl
+
+from torch.cuda.amp import autocast
+
+
+import triton
+import triton.language as tl
+#reference:  https://github.com/unslothai/unsloth-zoo/blob/main/unsloth_zoo/rl_replacements.py
+@triton.jit
+def grpo_loss_kernel(
+    # 输入指针
+    new_logits_ptr,    # [BL, V] 新策略 logits
+    ref_logits_ptr,    # [BL, V] 参考策略 logits
+    old_logits_ptr,    # [BL, V] 旧策略 logits
+    input_ids_ptr,     # [BL]    token 索引
+    advantages_ptr,    # [BL]    优势函数
+    mask_ptr,          # [BL]    掩码（有效 token）
+    # 输出指针
+    loss_ptr,          # [BL]    每个 token 的损失
+    kl_ptr,            # [BL]    每个 token 的 KL 散度
+    completion_length_ptr,  # [1]   平均生成长度
+    mean_kl_ptr,       # [1]    平均 KL 散度
+    # 常量参数
+    BL: tl.constexpr,          # 总样本数 (B*T)
+    V: tl.constexpr,           # 词汇表大小
+    BLOCK_M: tl.constexpr,     # 每个线程块处理的行数
+    max_completion_length: tl.constexpr,
+    beta: tl.constexpr,
+    delta: tl.constexpr,       # PPO 梯度裁剪阈值
+    epsilon_low: tl.constexpr,
+    epsilon_high: tl.constexpr,
+    TEMPERATURE: tl.constexpr,
+    logit_scale_multiply: tl.constexpr,
+    logit_scale_divide: tl.constexpr,
+    logit_softcapping: tl.constexpr,
+    loss_type: tl.constexpr,    # 0: grpo, 1: bnpo, 2: dr_grpo
+):
+    # 线程块 ID
+    pid = tl.program_id(0)
+    row0 = pid * BLOCK_M
+    offs_t = row0 + tl.arange(0, BLOCK_M)  # 当前块负责的行索引
+    m_t = offs_t < BL  # 防越界掩码
+
+    # 1. 加载 input_ids
+    ids = tl.load(input_ids_ptr + offs_t, mask=m_t, other=0)  # [BLOCK_M]
+    ids = tl.where(ids >= 0, ids, 0)  # 确保列索引合法
+
+    # 2. 加载 logits 并应用 logit 缩放/softcapping
+    col_idx = tl.arange(0, V)[None, :]  # [1, V]
+    ptr_new = new_logits_ptr + offs_t * V + ids
+    ptr_ref = ref_logits_ptr + offs_t * V + ids
+    ptr_old = old_logits_ptr + offs_t * V + ids
+    # 加载 logits 并应用 logit 缩放
+    new_logits_ptr_x = tl.load(new_logits_ptr + offs_t[:, None] * V + col_idx, mask=m_t[:, None], other=-float('inf'))
+    ref_logits_ptr_x = tl.load(ref_logits_ptr + offs_t[:, None] * V + col_idx, mask=m_t[:, None], other=-float('inf'))
+    old_logits_ptr_X = tl.load(old_logits_ptr + offs_t[:, None] * V + col_idx, mask=m_t[:, None], other=-float('inf'))
+    new_x = tl.load(ptr_new, mask=m_t, other=-float('inf'))  # 结果是 [BLOCK_M]
+    ref_x = tl.load(ptr_ref, mask=m_t, other=-float('inf'))  # 结果是 [BLOCK_M]
+    old_x = tl.load(ptr_old, mask=m_t, other=-float('inf'))  # 结果是 [BLOCK_M]
+    # 应用温度缩放
+    if TEMPERATURE != 1.0:
+        inv_temp = 1.0 / TEMPERATURE
+        new_logits_ptr_x = new_logits_ptr_x * inv_temp
+        ref_logits_ptr_x = ref_logits_ptr_x * inv_temp
+        old_logits_ptr_X = old_logits_ptr_X * inv_temp
+        new_x = new_x * inv_temp
+        ref_x = ref_x * inv_temp
+        old_x = old_x * inv_temp
+
+    # 4. 计算 logsumexp（分两阶段）
+  
+    max_val1 = tl.max(new_logits_ptr_x, axis=1)  # [BLOCK_M]
+    exp_logits1 = tl.exp(new_logits_ptr_x - max_val1[:, None])  # [BLOCK_M, V]
+    sum_exp = tl.sum(exp_logits1, axis=1)  # [BLOCK_M]
+    lse_new= max_val1 + tl.log(sum_exp)  # [BLOCK_M]
+    
+    max_val2 = tl.max(ref_logits_ptr_x, axis=1)  # [BLOCK_M]
+    exp_logits2 = tl.exp(ref_logits_ptr_x - max_val2[:, None])  # [BLOCK_M, V]
+    sum_exp2 = tl.sum(exp_logits2, axis=1)  # [BLOCK_M]
+    lse_ref= max_val2 + tl.log(sum_exp2)  # [BLOCK_M]
+    
+    
+    max_val3 = tl.max(old_logits_ptr_X, axis=1)  # [BLOCK_M]
+    exp_logits3 = tl.exp(old_logits_ptr_X - max_val3[:, None])  # [BLOCK_M, V]
+    sum_exp3= tl.sum(exp_logits3, axis=1)  # [BLOCK_M]
+    lse_old= max_val3 + tl.log(sum_exp3)  # [BLOCK_M]
+   
+
+    # 5. 计算 log probability
+    new_lp = new_x - lse_new
+    ref_lp = ref_x - lse_ref
+    old_lp = old_x - lse_old
+
+    # 6. 计算 KL 散度（Reverse KL 近似）
+    tmp = tl.exp(ref_lp - new_lp) - (ref_lp - new_lp) - 1.0
+    kl_i = tl.where(beta != 0.0, tmp, 0.0)  # 仅当 beta ≠ 0 时启用 KL 惩罚
+
+    # 7. PPO-style 梯度裁剪
+
+    coef1 = tl.exp(new_lp - old_lp)  # [BLOCK_M]
+    # coef2 = tl.clamp(coef1, 1.0 - epsilon_low, 1.0 + epsilon_high)  # [BLOCK_M]
+    coef2= tl.minimum(tl.maximum(coef1, 1.0 - epsilon_low), 1.0 + epsilon_high)
+    # 8. 加载优势函数
+    adv = tl.load(advantages_ptr + offs_t, mask=m_t, other=0.0)  # [BLOCK_M]
+
+    # 9. 计算损失项
+    if delta is not None:
+        loss1  = tl.minimum(coef1, delta)* adv
+    else:
+        loss1 = coef1 * adv
+    loss2 = coef2 * adv
+    loss_i = -tl.minimum(loss1, loss2)  # [BLOCK_M]
+    # 添加 KL 惩罚
+    if beta != 0.0:
+        loss_i += beta * kl_i
+
+    # 10. 应用 mask（忽略 padding token）
+    mask_val = tl.load(mask_ptr + offs_t, mask=m_t, other=0.0)  # [BLOCK_M]
+    loss_i_masked = loss_i * mask_val
+    kl_i_masked = kl_i * mask_val
+
+    # 11. 写入输出
+    tl.store(loss_ptr + offs_t, loss_i_masked, mask=m_t)
+    tl.store(kl_ptr + offs_t, kl_i_masked, mask=m_t)
+
+    # 12. 计算指标 放在pytorch中计算
+    # completion_length = mask_val.sum()
+    # mean_kl = (kl_i_masked).sum() / mask_val.sum()
+
+
+
+def grpo_loss_triton(
+    new_logits, ref_logits, old_logits, input_ids, advantages, mask,
+    beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
+    max_completion_length=8192, delta=None, temperature=1.0,
+    logit_scale_multiply=0.0, logit_scale_divide=0.0, logit_softcapping=0.0
+):
+    BL, V = new_logits.shape
+    BLOCK_M = 64
+    grid= ( (BL + BLOCK_M - 1) // BLOCK_M, )
+    loss = torch.empty(BL, device=new_logits.device)
+    kl = torch.empty(BL, device=new_logits.device)
+    completion_length = torch.tensor(0.0, device=new_logits.device)
+    mean_kl = torch.tensor(0.0, device=new_logits.device)
+
+    loss_type_code = {"grpo": 0, "bnpo": 1, "dr_grpo": 2}[loss_type]
+
+    grpo_loss_kernel[grid](
+        new_logits, ref_logits, old_logits, input_ids, advantages, mask,
+        loss, kl, completion_length, mean_kl,
+        BL=BL, V=V, BLOCK_M=BLOCK_M,
+        max_completion_length=max_completion_length,
+        beta=beta, epsilon_low=epsilon_low, epsilon_high=epsilon_high,delta=1,
+        TEMPERATURE=temperature, logit_scale_multiply=logit_scale_multiply,
+        logit_scale_divide=logit_scale_divide, logit_softcapping=logit_softcapping,
+        loss_type=loss_type_code
+    )
+
+    # 损失聚合（Triton 只写入 per-token loss_i）
+    mask = mask.to(torch.float32)
+    loss_i = loss
+    if loss_type == "grpo":
+        loss_aggregated = ((loss_i * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)).mean()
+    elif loss_type == "bnpo":
+        loss_aggregated = (loss_i * mask).sum() / mask.sum().clamp(min=1.0)
+    elif loss_type == "dr_grpo":
+        loss_aggregated = (loss_i * mask).sum() / (loss_i.size(0) * max_completion_length)
+
+    with torch.inference_mode():
+        completion_length = mask.sum().float().mean()
+        mean_kl = (kl * mask).sum() / mask.sum().clamp(min=1.0)
+        mean_kl = mean_kl.mean()
+
+    return loss_aggregated, completion_length, mean_kl, loss_i, kl
+

--- a/dlblas/kernels/grpo_compute_loss_logits.py
+++ b/dlblas/kernels/grpo_compute_loss_logits.py
@@ -11,167 +11,168 @@ import triton.language as tl
 @triton.jit
 def grpo_loss_kernel(
     # 输入指针
-    new_logits_ptr,    # [BL, V] 新策略 logits
-    ref_logits_ptr,    # [BL, V] 参考策略 logits
-    old_logits_ptr,    # [BL, V] 旧策略 logits
-    input_ids_ptr,     # [BL]    token 索引
-    advantages_ptr,    # [BL]    优势函数
-    mask_ptr,          # [BL]    掩码（有效 token）
+    new_logits_ptr, ref_logits_ptr, old_logits_ptr,
+    input_ids_ptr, advantages_ptr, mask_ptr,
+    # 预计算的 logsumexp 指针
+    lse_new_ptr, lse_ref_ptr, lse_old_ptr,
     # 输出指针
-    loss_ptr,          # [BL]    每个 token 的损失
-    kl_ptr,            # [BL]    每个 token 的 KL 散度
-    completion_length_ptr,  # [1]   平均生成长度
-    mean_kl_ptr,       # [1]    平均 KL 散度
+    loss_ptr, kl_ptr,
     # 常量参数
-    BL: tl.constexpr,          # 总样本数 (B*T)
-    V: tl.constexpr,           # 词汇表大小
-    BLOCK_M: tl.constexpr,     # 每个线程块处理的行数
-    max_completion_length: tl.constexpr,
-    beta: tl.constexpr,
-    delta: tl.constexpr,       # PPO 梯度裁剪阈值
-    epsilon_low: tl.constexpr,
-    epsilon_high: tl.constexpr,
+    BL: tl.constexpr,
+    V: tl.constexpr,  # [MODIFIED] V 必须作为 constexpr 显式传入
+    BLOCK_M: tl.constexpr,
+    beta: tl.constexpr, delta: tl.constexpr,
+    epsilon_low: tl.constexpr, epsilon_high: tl.constexpr,
     TEMPERATURE: tl.constexpr,
-    logit_scale_multiply: tl.constexpr,
-    logit_scale_divide: tl.constexpr,
-    logit_softcapping: tl.constexpr,
-    loss_type: tl.constexpr,    # 0: grpo, 1: bnpo, 2: dr_grpo
 ):
-    # 线程块 ID
     pid = tl.program_id(0)
     row0 = pid * BLOCK_M
-    offs_t = row0 + tl.arange(0, BLOCK_M)  # 当前块负责的行索引
-    m_t = offs_t < BL  # 防越界掩码
+    offs_t = row0 + tl.arange(0, BLOCK_M)
+    m_t = offs_t < BL
 
-    # 1. 加载 input_ids
-    ids = tl.load(input_ids_ptr + offs_t, mask=m_t, other=0)  # [BLOCK_M]
-    ids = tl.where(ids >= 0, ids, 0)  # 确保列索引合法
+    ids = tl.load(input_ids_ptr + offs_t, mask=m_t, other=0)
+    ids = tl.where(ids >= 0, ids, 0)
 
-    # 2. 加载 logits 并应用 logit 缩放/softcapping
-    col_idx = tl.arange(0, V)[None, :]  # [1, V]
-    ptr_new = new_logits_ptr + offs_t * V + ids
-    ptr_ref = ref_logits_ptr + offs_t * V + ids
-    ptr_old = old_logits_ptr + offs_t * V + ids
-    # 加载 logits 并应用 logit 缩放
-    new_logits_ptr_x = tl.load(new_logits_ptr + offs_t[:, None] * V + col_idx, mask=m_t[:, None], other=-float('inf'))
-    ref_logits_ptr_x = tl.load(ref_logits_ptr + offs_t[:, None] * V + col_idx, mask=m_t[:, None], other=-float('inf'))
-    old_logits_ptr_X = tl.load(old_logits_ptr + offs_t[:, None] * V + col_idx, mask=m_t[:, None], other=-float('inf'))
-    new_x = tl.load(ptr_new, mask=m_t, other=-float('inf'))  # 结果是 [BLOCK_M]
-    ref_x = tl.load(ptr_ref, mask=m_t, other=-float('inf'))  # 结果是 [BLOCK_M]
-    old_x = tl.load(ptr_old, mask=m_t, other=-float('inf'))  # 结果是 [BLOCK_M]
-    # 应用温度缩放
+    # [REMOVED] 不再从指针推断 V，因为它不可靠
+    # V = new_logits_ptr.shape[1]
+
+    # 只加载目标 token 的 logit
+    new_x = tl.load(new_logits_ptr + offs_t * V + ids, mask=m_t, other=-float('inf'))
+    ref_x = tl.load(ref_logits_ptr + offs_t * V + ids, mask=m_t, other=-float('inf'))
+    old_x = tl.load(old_logits_ptr + offs_t * V + ids, mask=m_t, other=-float('inf'))
+
     if TEMPERATURE != 1.0:
         inv_temp = 1.0 / TEMPERATURE
-        new_logits_ptr_x = new_logits_ptr_x * inv_temp
-        ref_logits_ptr_x = ref_logits_ptr_x * inv_temp
-        old_logits_ptr_X = old_logits_ptr_X * inv_temp
-        new_x = new_x * inv_temp
-        ref_x = ref_x * inv_temp
-        old_x = old_x * inv_temp
+        new_x, ref_x, old_x = new_x * inv_temp, ref_x * inv_temp, old_x * inv_temp
 
-    # 4. 计算 logsumexp（分两阶段）
-  
-    max_val1 = tl.max(new_logits_ptr_x, axis=1)  # [BLOCK_M]
-    exp_logits1 = tl.exp(new_logits_ptr_x - max_val1[:, None])  # [BLOCK_M, V]
-    sum_exp = tl.sum(exp_logits1, axis=1)  # [BLOCK_M]
-    lse_new= max_val1 + tl.log(sum_exp)  # [BLOCK_M]
+    # 直接加载预先计算好的 logsumexp 值
+    lse_new = tl.load(lse_new_ptr + offs_t, mask=m_t, other=0.0)
+    lse_ref = tl.load(lse_ref_ptr + offs_t, mask=m_t, other=0.0)
+    lse_old = tl.load(lse_old_ptr + offs_t, mask=m_t, other=0.0)
+
+    # 后续逻辑保持不变
+    new_lp, ref_lp, old_lp = new_x - lse_new, ref_x - lse_ref, old_x - lse_old
+
+    tmp_kl = tl.exp(ref_lp - new_lp) - (ref_lp - new_lp) - 1.0
+    kl_i = tl.where(beta != 0.0, tmp_kl, 0.0)
+
+    coef1 = tl.exp(new_lp - old_lp)
+    coef2 = tl.minimum(tl.maximum(coef1, 1.0 - epsilon_low), 1.0 + epsilon_high)
     
-    max_val2 = tl.max(ref_logits_ptr_x, axis=1)  # [BLOCK_M]
-    exp_logits2 = tl.exp(ref_logits_ptr_x - max_val2[:, None])  # [BLOCK_M, V]
-    sum_exp2 = tl.sum(exp_logits2, axis=1)  # [BLOCK_M]
-    lse_ref= max_val2 + tl.log(sum_exp2)  # [BLOCK_M]
-    
-    
-    max_val3 = tl.max(old_logits_ptr_X, axis=1)  # [BLOCK_M]
-    exp_logits3 = tl.exp(old_logits_ptr_X - max_val3[:, None])  # [BLOCK_M, V]
-    sum_exp3= tl.sum(exp_logits3, axis=1)  # [BLOCK_M]
-    lse_old= max_val3 + tl.log(sum_exp3)  # [BLOCK_M]
-   
+    adv = tl.load(advantages_ptr + offs_t, mask=m_t, other=0.0)
 
-    # 5. 计算 log probability
-    new_lp = new_x - lse_new
-    ref_lp = ref_x - lse_ref
-    old_lp = old_x - lse_old
-
-    # 6. 计算 KL 散度（Reverse KL 近似）
-    tmp = tl.exp(ref_lp - new_lp) - (ref_lp - new_lp) - 1.0
-    kl_i = tl.where(beta != 0.0, tmp, 0.0)  # 仅当 beta ≠ 0 时启用 KL 惩罚
-
-    # 7. PPO-style 梯度裁剪
-
-    coef1 = tl.exp(new_lp - old_lp)  # [BLOCK_M]
-    # coef2 = tl.clamp(coef1, 1.0 - epsilon_low, 1.0 + epsilon_high)  # [BLOCK_M]
-    coef2= tl.minimum(tl.maximum(coef1, 1.0 - epsilon_low), 1.0 + epsilon_high)
-    # 8. 加载优势函数
-    adv = tl.load(advantages_ptr + offs_t, mask=m_t, other=0.0)  # [BLOCK_M]
-
-    # 9. 计算损失项
-    if delta is not None:
-        loss1  = tl.minimum(coef1, delta)* adv
+    if delta != -1.0:
+        loss1 = tl.minimum(coef1, delta) * adv
     else:
         loss1 = coef1 * adv
     loss2 = coef2 * adv
-    loss_i = -tl.minimum(loss1, loss2)  # [BLOCK_M]
-    # 添加 KL 惩罚
+    loss_i = -tl.minimum(loss1, loss2)
+
     if beta != 0.0:
         loss_i += beta * kl_i
 
-    # 10. 应用 mask（忽略 padding token）
-    mask_val = tl.load(mask_ptr + offs_t, mask=m_t, other=0.0)  # [BLOCK_M]
+    mask_val = tl.load(mask_ptr + offs_t, mask=m_t, other=0.0)
     loss_i_masked = loss_i * mask_val
     kl_i_masked = kl_i * mask_val
 
-    # 11. 写入输出
     tl.store(loss_ptr + offs_t, loss_i_masked, mask=m_t)
     tl.store(kl_ptr + offs_t, kl_i_masked, mask=m_t)
 
-    # 12. 计算指标 放在pytorch中计算
-    # completion_length = mask_val.sum()
-    # mean_kl = (kl_i_masked).sum() / mask_val.sum()
 
+def grpo_compute_loss_torch(
+    new_logits, ref_logits, old_logits, input_ids, advantages, mask,
+    beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
+    max_completion_length=8192, delta=None, temperature=1.0,
+):
+    # PyTorch 参考实现保持不变
+    new_logits, ref_logits, old_logits = new_logits.to(torch.float32), ref_logits.to(torch.float32), old_logits.to(torch.float32)
+
+    if temperature != 1.0:
+        new_logits, ref_logits, old_logits = new_logits / temperature, ref_logits / temperature, old_logits / temperature
+
+    input_ids_expanded = input_ids.unsqueeze(-1)
+    new_x = torch.gather(new_logits, dim=-1, index=input_ids_expanded).squeeze(-1)
+    ref_x = torch.gather(ref_logits, dim=-1, index=input_ids_expanded).squeeze(-1)
+    old_x = torch.gather(old_logits, dim=-1, index=input_ids_expanded).squeeze(-1)
+
+    lse_new, lse_ref, lse_old = torch.logsumexp(new_logits, dim=-1), torch.logsumexp(ref_logits, dim=-1), torch.logsumexp(old_logits, dim=-1)
+    new_lp, ref_lp, old_lp = new_x - lse_new, ref_x - lse_ref, old_x - lse_old
+
+    kl_i = torch.exp(ref_lp - new_lp) - (ref_lp - new_lp) - 1.0 if beta != 0.0 else torch.zeros_like(ref_lp)
+
+    coef1 = torch.exp(new_lp - old_lp)
+    coef2 = torch.clamp(coef1, 1 - epsilon_low, 1 + epsilon_high)
+
+    loss1 = torch.clamp(coef1, max=delta) * advantages if delta is not None else coef1 * advantages
+    loss2 = coef2 * advantages
+    loss_i = -torch.min(loss1, loss2)
+    if beta != 0.0:
+        loss_i += beta * kl_i
+
+    mask_float = mask.to(torch.float32)
+    masked_loss_i = loss_i * mask_float
+    
+    if loss_type == "grpo" or loss_type == "bnpo":
+        loss = masked_loss_i.sum() / mask_float.sum().clamp(min=1.0)
+    elif loss_type == "dr_grpo":
+        loss = masked_loss_i.sum() / (loss_i.size(0) * max_completion_length)
+    else:
+        raise ValueError(f"Unknown loss type: {loss_type}")
+
+    with torch.inference_mode():
+        completion_length = mask_float.sum()
+        mean_kl = (kl_i * mask_float).sum() / mask_float.sum().clamp(min=1.0)
+
+    return loss, completion_length, mean_kl, masked_loss_i, kl_i * mask_float
 
 
 def grpo_loss_triton(
     new_logits, ref_logits, old_logits, input_ids, advantages, mask,
     beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
     max_completion_length=8192, delta=None, temperature=1.0,
-    logit_scale_multiply=0.0, logit_scale_divide=0.0, logit_softcapping=0.0
 ):
     BL, V = new_logits.shape
     BLOCK_M = 64
-    grid= ( (BL + BLOCK_M - 1) // BLOCK_M, )
-    loss = torch.empty(BL, device=new_logits.device)
-    kl = torch.empty(BL, device=new_logits.device)
-    completion_length = torch.tensor(0.0, device=new_logits.device)
-    mean_kl = torch.tensor(0.0, device=new_logits.device)
+    grid = ((BL + BLOCK_M - 1) // BLOCK_M, )
+    
+    loss_i = torch.empty(BL, device=new_logits.device, dtype=torch.float32)
+    kl_i = torch.empty(BL, device=new_logits.device, dtype=torch.float32)
 
-    loss_type_code = {"grpo": 0, "bnpo": 1, "dr_grpo": 2}[loss_type]
+    delta_kernel = delta if delta is not None else -1.0
+
+    # 预计算 logsumexp
+    new_logits_scaled = new_logits.to(torch.float32)
+    ref_logits_scaled = ref_logits.to(torch.float32)
+    old_logits_scaled = old_logits.to(torch.float32)
+    
+    if temperature != 1.0:
+        new_logits_scaled, ref_logits_scaled, old_logits_scaled = new_logits_scaled / temperature, ref_logits_scaled / temperature, old_logits_scaled / temperature
+    
+    lse_new = torch.logsumexp(new_logits_scaled, dim=-1)
+    lse_ref = torch.logsumexp(ref_logits_scaled, dim=-1)
+    lse_old = torch.logsumexp(old_logits_scaled, dim=-1)
 
     grpo_loss_kernel[grid](
         new_logits, ref_logits, old_logits, input_ids, advantages, mask,
-        loss, kl, completion_length, mean_kl,
-        BL=BL, V=V, BLOCK_M=BLOCK_M,
-        max_completion_length=max_completion_length,
-        beta=beta, epsilon_low=epsilon_low, epsilon_high=epsilon_high,delta=1,
-        TEMPERATURE=temperature, logit_scale_multiply=logit_scale_multiply,
-        logit_scale_divide=logit_scale_divide, logit_softcapping=logit_softcapping,
-        loss_type=loss_type_code
+        lse_new, lse_ref, lse_old,
+        loss_i, kl_i,
+        BL=BL,
+        V=V,  # [MODIFIED] 将 V 显式传入内核
+        BLOCK_M=BLOCK_M,
+        beta=beta, epsilon_low=epsilon_low, epsilon_high=epsilon_high, delta=delta_kernel,
+        TEMPERATURE=temperature,
     )
 
-    # 损失聚合（Triton 只写入 per-token loss_i）
-    mask = mask.to(torch.float32)
-    loss_i = loss
-    if loss_type == "grpo":
-        loss_aggregated = ((loss_i * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)).mean()
-    elif loss_type == "bnpo":
-        loss_aggregated = (loss_i * mask).sum() / mask.sum().clamp(min=1.0)
+    mask_float = mask.to(torch.float32)
+    if loss_type == "grpo" or loss_type == "bnpo":
+        loss_aggregated = loss_i.sum() / mask_float.sum().clamp(min=1.0)
     elif loss_type == "dr_grpo":
-        loss_aggregated = (loss_i * mask).sum() / (loss_i.size(0) * max_completion_length)
+        loss_aggregated = loss_i.sum() / (loss_i.size(0) * max_completion_length)
+    else:
+        raise ValueError(f"Unknown loss type: {loss_type}")
 
     with torch.inference_mode():
-        completion_length = mask.sum().float().mean()
-        mean_kl = (kl * mask).sum() / mask.sum().clamp(min=1.0)
-        mean_kl = mean_kl.mean()
+        completion_length = mask_float.sum()
+        mean_kl = kl_i.sum() / mask_float.sum().clamp(min=1.0)
 
-    return loss_aggregated, completion_length, mean_kl, loss_i, kl
-
+    return loss_aggregated, completion_length, mean_kl, loss_i, kl_i

--- a/dlblas/kernels/grpo_compute_loss_logits.py
+++ b/dlblas/kernels/grpo_compute_loss_logits.py
@@ -9,72 +9,34 @@ import triton
 import triton.language as tl
 #reference:  https://github.com/unslothai/unsloth-zoo/blob/main/unsloth_zoo/rl_replacements.py
 @triton.jit
-def grpo_loss_triton_kernel(
+def grpo_loss_kernel(
     # 输入指针
     new_logits_ptr, ref_logits_ptr, old_logits_ptr,
     input_ids_ptr, advantages_ptr, mask_ptr,
+    # 预计算的 logsumexp 指针
+    lse_new_ptr, lse_ref_ptr, lse_old_ptr,
     # 输出指针
     loss_ptr, kl_ptr,
     # 常量参数
-    BL: tl.constexpr, V: tl.constexpr,
-    BLOCK_M: tl.constexpr, BLOCK_V: tl.constexpr,
+    BL: tl.constexpr,
+    V: tl.constexpr,  # [MODIFIED] V 必须作为 constexpr 显式传入
+    BLOCK_M: tl.constexpr,
     beta: tl.constexpr, delta: tl.constexpr,
     epsilon_low: tl.constexpr, epsilon_high: tl.constexpr,
     TEMPERATURE: tl.constexpr,
 ):
     pid = tl.program_id(0)
     row0 = pid * BLOCK_M
-    offs_t = row0 + tl.arange(0, BLOCK_M)  # [BLOCK_M], 负责的行索引
-    m_t = offs_t < BL  # [BLOCK_M], 行掩码
-
- 
-    m_new, m_ref, m_old = tl.full([BLOCK_M], -float('inf'), dtype=tl.float32), tl.full([BLOCK_M], -float('inf'), dtype=tl.float32), tl.full([BLOCK_M], -float('inf'), dtype=tl.float32)
-    s_new, s_ref, s_old = tl.zeros([BLOCK_M], dtype=tl.float32), tl.zeros([BLOCK_M], dtype=tl.float32), tl.zeros([BLOCK_M], dtype=tl.float32)
-
-    # 内部循环，分块处理每一行
-    for v_start in range(0, V, BLOCK_V):
-        # 计算当前块的列偏移量
-        v_offs = v_start + tl.arange(0, BLOCK_V)  # [BLOCK_V]
-        v_mask = v_offs < V  # [BLOCK_V], 列掩码
-
-        # --- 为 new_logits 更新 logsumexp ---
-        # 加载一个 logits 块: [BLOCK_M, BLOCK_V]
-        new_chunk = tl.load(new_logits_ptr + offs_t[:, None] * V + v_offs[None, :], mask=m_t[:, None] & v_mask[None, :], other=-float('inf'))
-        if TEMPERATURE != 1.0: new_chunk /= TEMPERATURE
-        
-        # 在块内找到最大值
-        chunk_m_new = tl.max(new_chunk, axis=1)
-        # 更新全局最大值
-        new_m_new = tl.maximum(m_new, chunk_m_new)
-        # 更新 sum (这是数值稳定的关键步骤)
-        s_new = s_new * tl.exp(m_new - new_m_new) + tl.sum(tl.exp(new_chunk - new_m_new[:, None]), axis=1)
-        m_new = new_m_new
-
-        # --- 为 ref_logits 更新 logsumexp ---
-        ref_chunk = tl.load(ref_logits_ptr + offs_t[:, None] * V + v_offs[None, :], mask=m_t[:, None] & v_mask[None, :], other=-float('inf'))
-        if TEMPERATURE != 1.0: ref_chunk /= TEMPERATURE
-        chunk_m_ref = tl.max(ref_chunk, axis=1)
-        new_m_ref = tl.maximum(m_ref, chunk_m_ref)
-        s_ref = s_ref * tl.exp(m_ref - new_m_ref) + tl.sum(tl.exp(ref_chunk - new_m_ref[:, None]), axis=1)
-        m_ref = new_m_ref
-
-        # --- 为 old_logits 更新 logsumexp ---
-        old_chunk = tl.load(old_logits_ptr + offs_t[:, None] * V + v_offs[None, :], mask=m_t[:, None] & v_mask[None, :], other=-float('inf'))
-        if TEMPERATURE != 1.0: old_chunk /= TEMPERATURE
-        chunk_m_old = tl.max(old_chunk, axis=1)
-        new_m_old = tl.maximum(m_old, chunk_m_old)
-        s_old = s_old * tl.exp(m_old - new_m_old) + tl.sum(tl.exp(old_chunk - new_m_old[:, None]), axis=1)
-        m_old = new_m_old
-
-    # 循环结束后，完成 logsumexp 的计算
-    lse_new = m_new + tl.log(s_new)
-    lse_ref = m_ref + tl.log(s_ref)
-    lse_old = m_old + tl.log(s_old)
-
+    offs_t = row0 + tl.arange(0, BLOCK_M)
+    m_t = offs_t < BL
 
     ids = tl.load(input_ids_ptr + offs_t, mask=m_t, other=0)
     ids = tl.where(ids >= 0, ids, 0)
 
+    # [REMOVED] 不再从指针推断 V，因为它不可靠
+    # V = new_logits_ptr.shape[1]
+
+    # 只加载目标 token 的 logit
     new_x = tl.load(new_logits_ptr + offs_t * V + ids, mask=m_t, other=-float('inf'))
     ref_x = tl.load(ref_logits_ptr + offs_t * V + ids, mask=m_t, other=-float('inf'))
     old_x = tl.load(old_logits_ptr + offs_t * V + ids, mask=m_t, other=-float('inf'))
@@ -83,6 +45,12 @@ def grpo_loss_triton_kernel(
         inv_temp = 1.0 / TEMPERATURE
         new_x, ref_x, old_x = new_x * inv_temp, ref_x * inv_temp, old_x * inv_temp
 
+    # 直接加载预先计算好的 logsumexp 值
+    lse_new = tl.load(lse_new_ptr + offs_t, mask=m_t, other=0.0)
+    lse_ref = tl.load(lse_ref_ptr + offs_t, mask=m_t, other=0.0)
+    lse_old = tl.load(lse_old_ptr + offs_t, mask=m_t, other=0.0)
+
+    # 后续逻辑保持不变
     new_lp, ref_lp, old_lp = new_x - lse_new, ref_x - lse_ref, old_x - lse_old
 
     tmp_kl = tl.exp(ref_lp - new_lp) - (ref_lp - new_lp) - 1.0
@@ -111,67 +79,23 @@ def grpo_loss_triton_kernel(
     tl.store(kl_ptr + offs_t, kl_i_masked, mask=m_t)
 
 
-def grpo_loss_triton(
-    new_logits, ref_logits, old_logits, input_ids, advantages, mask,
-    beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
-    max_completion_length=8192, delta=None, temperature=1.0,
-):
-    BL, V = new_logits.shape
-    
-    # 定义块大小
-    BLOCK_M = 64  
-    BLOCK_V = 2048 
-    
-    grid = ((BL + BLOCK_M - 1) // BLOCK_M, )
-    
-    loss_i = torch.empty(BL, device=new_logits.device, dtype=torch.float32)
-    kl_i = torch.empty(BL, device=new_logits.device, dtype=torch.float32)
-
-    delta_kernel = delta if delta is not None else -1.0
-
-    grpo_loss_triton_kernel[grid](
-        new_logits, ref_logits, old_logits, input_ids, advantages, mask,
-        loss_i, kl_i,
-        BL=BL, V=V,
-        BLOCK_M=BLOCK_M, BLOCK_V=BLOCK_V,
-        beta=beta, epsilon_low=epsilon_low, epsilon_high=epsilon_high, delta=delta_kernel,
-        TEMPERATURE=temperature,
-    )
-
-    # 后续的聚合逻辑与之前相同
-    mask_float = mask.to(torch.float32)
-    if loss_type == "grpo" or loss_type == "bnpo":
-        loss_aggregated = loss_i.sum() / mask_float.sum().clamp(min=1.0)
-    elif loss_type == "dr_grpo":
-        loss_aggregated = loss_i.sum() / (loss_i.size(0) * max_completion_length)
-    else:
-        raise ValueError(f"Unknown loss type: {loss_type}")
-
-    with torch.inference_mode():
-        completion_length = mask_float.sum()
-        mean_kl = kl_i.sum() / mask_float.sum().clamp(min=1.0)
-
-    return loss_aggregated, completion_length, mean_kl, loss_i, kl_i
-
-
-
 def grpo_compute_loss_torch(
     new_logits, ref_logits, old_logits, input_ids, advantages, mask,
     beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
     max_completion_length=8192, delta=None, temperature=1.0,
 ):
-   
-    new_logits_fp32, ref_logits_fp32, old_logits_fp32 = new_logits.to(torch.float32), ref_logits.to(torch.float32), old_logits.to(torch.float32)
+    # PyTorch 参考实现保持不变
+    new_logits, ref_logits, old_logits = new_logits.to(torch.float32), ref_logits.to(torch.float32), old_logits.to(torch.float32)
 
     if temperature != 1.0:
-        new_logits_fp32, ref_logits_fp32, old_logits_fp32 = new_logits_fp32 / temperature, ref_logits_fp32 / temperature, old_logits_fp32 / temperature
+        new_logits, ref_logits, old_logits = new_logits / temperature, ref_logits / temperature, old_logits / temperature
 
     input_ids_expanded = input_ids.unsqueeze(-1)
-    new_x = torch.gather(new_logits_fp32, dim=-1, index=input_ids_expanded).squeeze(-1)
-    ref_x = torch.gather(ref_logits_fp32, dim=-1, index=input_ids_expanded).squeeze(-1)
-    old_x = torch.gather(old_logits_fp32, dim=-1, index=input_ids_expanded).squeeze(-1)
+    new_x = torch.gather(new_logits, dim=-1, index=input_ids_expanded).squeeze(-1)
+    ref_x = torch.gather(ref_logits, dim=-1, index=input_ids_expanded).squeeze(-1)
+    old_x = torch.gather(old_logits, dim=-1, index=input_ids_expanded).squeeze(-1)
 
-    lse_new, lse_ref, lse_old = torch.logsumexp(new_logits_fp32, dim=-1), torch.logsumexp(ref_logits_fp32, dim=-1), torch.logsumexp(old_logits_fp32, dim=-1)
+    lse_new, lse_ref, lse_old = torch.logsumexp(new_logits, dim=-1), torch.logsumexp(ref_logits, dim=-1), torch.logsumexp(old_logits, dim=-1)
     new_lp, ref_lp, old_lp = new_x - lse_new, ref_x - lse_ref, old_x - lse_old
 
     kl_i = torch.exp(ref_lp - new_lp) - (ref_lp - new_lp) - 1.0 if beta != 0.0 else torch.zeros_like(ref_lp)
@@ -190,6 +114,8 @@ def grpo_compute_loss_torch(
     
     if loss_type == "grpo" or loss_type == "bnpo":
         loss = masked_loss_i.sum() / mask_float.sum().clamp(min=1.0)
+    elif loss_type == "dr_grpo":
+        loss = masked_loss_i.sum() / (loss_i.size(0) * max_completion_length)
     else:
         raise ValueError(f"Unknown loss type: {loss_type}")
 
@@ -198,3 +124,55 @@ def grpo_compute_loss_torch(
         mean_kl = (kl_i * mask_float).sum() / mask_float.sum().clamp(min=1.0)
 
     return loss, completion_length, mean_kl, masked_loss_i, kl_i * mask_float
+
+
+def grpo_loss_triton(
+    new_logits, ref_logits, old_logits, input_ids, advantages, mask,
+    beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
+    max_completion_length=8192, delta=None, temperature=1.0,
+):
+    BL, V = new_logits.shape
+    BLOCK_M = 64
+    grid = ((BL + BLOCK_M - 1) // BLOCK_M, )
+    
+    loss_i = torch.empty(BL, device=new_logits.device, dtype=torch.float32)
+    kl_i = torch.empty(BL, device=new_logits.device, dtype=torch.float32)
+
+    delta_kernel = delta if delta is not None else -1.0
+
+    # 计算 logsumexp
+    new_logits_scaled = new_logits.to(torch.float32)
+    ref_logits_scaled = ref_logits.to(torch.float32)
+    old_logits_scaled = old_logits.to(torch.float32)
+    
+    if temperature != 1.0:
+        new_logits_scaled, ref_logits_scaled, old_logits_scaled = new_logits_scaled / temperature, ref_logits_scaled / temperature, old_logits_scaled / temperature
+    
+    lse_new = torch.logsumexp(new_logits_scaled, dim=-1)
+    lse_ref = torch.logsumexp(ref_logits_scaled, dim=-1)
+    lse_old = torch.logsumexp(old_logits_scaled, dim=-1)
+
+    grpo_loss_kernel[grid](
+        new_logits, ref_logits, old_logits, input_ids, advantages, mask,
+        lse_new, lse_ref, lse_old,
+        loss_i, kl_i,
+        BL=BL,
+        V=V,  # [MODIFIED] 将 V 显式传入内核
+        BLOCK_M=BLOCK_M,
+        beta=beta, epsilon_low=epsilon_low, epsilon_high=epsilon_high, delta=delta_kernel,
+        TEMPERATURE=temperature,
+    )
+
+    mask_float = mask.to(torch.float32)
+    if loss_type == "grpo" or loss_type == "bnpo":
+        loss_aggregated = loss_i.sum() / mask_float.sum().clamp(min=1.0)
+    elif loss_type == "dr_grpo":
+        loss_aggregated = loss_i.sum() / (loss_i.size(0) * max_completion_length)
+    else:
+        raise ValueError(f"Unknown loss type: {loss_type}")
+
+    with torch.inference_mode():
+        completion_length = mask_float.sum()
+        mean_kl = kl_i.sum() / mask_float.sum().clamp(min=1.0)
+
+    return loss_aggregated, completion_length, mean_kl, loss_i, kl_i

--- a/tests/kernels/test_grpo_loss_logits.py
+++ b/tests/kernels/test_grpo_loss_logits.py
@@ -1,0 +1,158 @@
+import torch
+from from dlblas.kernels.grpo_compute_loss_logits import grpo_loss_triton
+
+def grpo_compute_loss_torch(
+    new_logits, ref_logits, old_logits, input_ids, advantages, mask,
+    beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
+    max_completion_length=8192, delta=1, temperature=1.0,
+    logit_scale_multiply=0.0, logit_scale_divide=0.0, logit_softcapping=0.0
+):
+
+    new_logits = new_logits.to(torch.float32)
+    ref_logits = ref_logits.to(torch.float32)
+    if old_logits is not None:
+        old_logits = old_logits.to(torch.float32)
+
+    # 温度缩放
+    if temperature != 1.0:
+        new_logits = new_logits / temperature
+        ref_logits = ref_logits / temperature
+        if old_logits is not None:
+            old_logits = old_logits / temperature
+
+    # 提取 log probability
+    input_ids = input_ids.unsqueeze(-1)
+    new_x = torch.gather(new_logits, dim=-1, index=input_ids).squeeze(-1)
+    ref_x = torch.gather(ref_logits, dim=-1, index=input_ids).squeeze(-1)
+    if old_logits is not None:
+        old_x = torch.gather(old_logits, dim=-1, index=input_ids).squeeze(-1)
+    else:
+        old_x = None
+
+    # 计算 logsumexp
+    lse_new = torch.logsumexp(new_logits, dim=-1)
+    lse_ref = torch.logsumexp(ref_logits, dim=-1)
+    if old_logits is not None:
+        lse_old = torch.logsumexp(old_logits, dim=-1)
+    else:
+        lse_old = None
+
+    # 计算 log probability
+    new_lp = new_x - lse_new
+    ref_lp = ref_x - lse_ref
+    if old_logits is not None:
+        old_lp = old_x - lse_old
+    else:
+        old_lp = None
+
+    # KL 散度计算
+    if beta != 0.0:
+        kl_i = torch.exp(ref_lp - new_lp) - (ref_lp - new_lp) - 1.0
+    else:
+        kl_i = torch.zeros_like(ref_lp)
+
+    # 梯度裁剪
+    if old_logits is not None:
+        coef1 = torch.exp(new_lp - old_lp)
+    else:
+        coef1 = torch.exp(new_lp - new_lp.detach())
+
+    coef2 = torch.clamp(coef1, 1 - epsilon_low, 1 + epsilon_high)
+
+    if delta is not None:
+        loss1 = torch.clamp(coef1, max=delta) * advantages
+    else:
+        loss1 = coef1 * advantages
+
+    loss2 = coef2 * advantages
+    loss_i = -torch.min(loss1, loss2)
+
+    if beta != 0.0:
+        loss_i += beta * kl_i
+
+    # 损失聚合
+    mask = mask.to(torch.float32)
+    if loss_type == "grpo":
+        loss = ((loss_i * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)).mean()
+    elif loss_type == "bnpo":
+        loss = (loss_i * mask).sum() / mask.sum().clamp(min=1.0)
+    elif loss_type == "dr_grpo":
+        loss = (loss_i * mask).sum() / (loss_i.size(0) * max_completion_length)
+    else:
+        raise ValueError(f"Unknown loss type: {loss_type}")
+
+    with torch.inference_mode():
+        completion_length = mask.sum().float().mean()
+        mean_kl = (kl_i * mask).sum() / mask.sum().clamp(min=1.0)
+        mean_kl = mean_kl.mean()
+
+    return loss, completion_length, mean_kl, loss_i, kl_i, new_lp, ref_lp, old_lp
+
+def test_grpo_loss():
+    # 设置随机种子
+    torch.manual_seed(0)
+
+    # 配置参数
+    BL = 1024   # 总 token 数
+    V = 512        # 词汇表大小
+    temperature = 2.0
+    beta = 0.1
+    epsilon_low = 0.2
+    epsilon_high = 0.2
+    loss_type = "grpo"
+    logit_scale_multiply = 0.5
+    logit_scale_divide = 2.0
+    logit_softcapping = 10.0
+
+    # 构造输入数据
+    new_logits = torch.randn((BL, V), device='cuda', requires_grad=True)
+    ref_logits = torch.randn((BL, V), device='cuda')
+    old_logits = torch.randn((BL, V), device='cuda')
+    input_ids = torch.randint(0, V, (BL,), device='cuda')
+    advantages = torch.randn((BL,), device='cuda')
+    mask = torch.randint(0, 2, (BL,), device='cuda').bool()
+
+    # PyTorch 计算
+    loss_pt, completion_pt, mean_kl_pt, loss_i_pt, kl_i_pt, new_lp_pt, ref_lp_pt, old_lp_pt = grpo_compute_loss_torch(
+        new_logits, ref_logits, old_logits, input_ids, advantages, mask,
+        beta=beta, loss_type=loss_type,
+        epsilon_low=epsilon_low, epsilon_high=epsilon_high,
+        temperature=temperature,
+        logit_scale_multiply=logit_scale_multiply,
+        logit_scale_divide=logit_scale_divide,
+        logit_softcapping=logit_softcapping
+    )
+
+    # Triton 计算
+    loss_tr, completion_tr, mean_kl_tr, loss_i_tr, kl_i_tr = grpo_loss_triton(
+        new_logits, ref_logits, old_logits, input_ids, advantages, mask,
+        beta=beta, loss_type=loss_type,
+        epsilon_low=epsilon_low, epsilon_high=epsilon_high,
+        temperature=temperature,
+        logit_scale_multiply=logit_scale_multiply,
+        logit_scale_divide=logit_scale_divide,
+        logit_softcapping=logit_softcapping
+    )
+
+    # ----------------------------
+    # 比较输出
+    # ----------------------------
+    print("Loss (Torch):", loss_pt.item())
+    print("Loss (Triton):", loss_tr.item())
+    assert torch.allclose(loss_pt, loss_tr, atol=1e-3, rtol=1e-3), "Loss 不一致"
+
+    print("Mean KL (Torch):", mean_kl_pt.item())
+    print("Mean KL (Triton):", mean_kl_tr.item())
+    assert torch.allclose(mean_kl_pt, mean_kl_tr, atol=1e-3, rtol=1e-3), "Mean KL 不一致"
+
+    print("Completion Length (Torch):", completion_pt.item())
+    print("Completion Length (Triton):", completion_tr.item())
+    assert torch.allclose(completion_pt, completion_tr, atol=1e-3, rtol=1e-3), "Completion Length 不一致"
+    
+    float_mask = mask.to(torch.float32)
+    assert torch.allclose(loss_i_pt * float_mask, loss_i_tr, atol=1e-3, rtol=1e-3), "Masked Loss_i 不一致"
+
+    # 对 kl_i 做同样的操作
+    assert torch.allclose(kl_i_pt * float_mask, kl_i_tr, atol=1e-3, rtol=1e-3), "Masked KL_i 不一致"
+
+    print("✅ 数值一致性验证通过！")

--- a/tests/kernels/test_grpo_loss_logits.py
+++ b/tests/kernels/test_grpo_loss_logits.py
@@ -1,158 +1,91 @@
+
+import unittest
 import torch
-from from dlblas.kernels.grpo_compute_loss_logits import grpo_loss_triton
+from  dlblas.kernels.grpo_compute_loss_logits import grpo_compute_loss_torch, grpo_loss_triton
 
-def grpo_compute_loss_torch(
-    new_logits, ref_logits, old_logits, input_ids, advantages, mask,
-    beta=0.1, loss_type="grpo", epsilon_low=0.2, epsilon_high=0.2,
-    max_completion_length=8192, delta=1, temperature=1.0,
-    logit_scale_multiply=0.0, logit_scale_divide=0.0, logit_softcapping=0.0
-):
-
-    new_logits = new_logits.to(torch.float32)
-    ref_logits = ref_logits.to(torch.float32)
-    if old_logits is not None:
-        old_logits = old_logits.to(torch.float32)
-
-    # 温度缩放
-    if temperature != 1.0:
-        new_logits = new_logits / temperature
-        ref_logits = ref_logits / temperature
-        if old_logits is not None:
-            old_logits = old_logits / temperature
-
-    # 提取 log probability
-    input_ids = input_ids.unsqueeze(-1)
-    new_x = torch.gather(new_logits, dim=-1, index=input_ids).squeeze(-1)
-    ref_x = torch.gather(ref_logits, dim=-1, index=input_ids).squeeze(-1)
-    if old_logits is not None:
-        old_x = torch.gather(old_logits, dim=-1, index=input_ids).squeeze(-1)
-    else:
-        old_x = None
-
-    # 计算 logsumexp
-    lse_new = torch.logsumexp(new_logits, dim=-1)
-    lse_ref = torch.logsumexp(ref_logits, dim=-1)
-    if old_logits is not None:
-        lse_old = torch.logsumexp(old_logits, dim=-1)
-    else:
-        lse_old = None
-
-    # 计算 log probability
-    new_lp = new_x - lse_new
-    ref_lp = ref_x - lse_ref
-    if old_logits is not None:
-        old_lp = old_x - lse_old
-    else:
-        old_lp = None
-
-    # KL 散度计算
-    if beta != 0.0:
-        kl_i = torch.exp(ref_lp - new_lp) - (ref_lp - new_lp) - 1.0
-    else:
-        kl_i = torch.zeros_like(ref_lp)
-
-    # 梯度裁剪
-    if old_logits is not None:
-        coef1 = torch.exp(new_lp - old_lp)
-    else:
-        coef1 = torch.exp(new_lp - new_lp.detach())
-
-    coef2 = torch.clamp(coef1, 1 - epsilon_low, 1 + epsilon_high)
-
-    if delta is not None:
-        loss1 = torch.clamp(coef1, max=delta) * advantages
-    else:
-        loss1 = coef1 * advantages
-
-    loss2 = coef2 * advantages
-    loss_i = -torch.min(loss1, loss2)
-
-    if beta != 0.0:
-        loss_i += beta * kl_i
-
-    # 损失聚合
-    mask = mask.to(torch.float32)
-    if loss_type == "grpo":
-        loss = ((loss_i * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)).mean()
-    elif loss_type == "bnpo":
-        loss = (loss_i * mask).sum() / mask.sum().clamp(min=1.0)
-    elif loss_type == "dr_grpo":
-        loss = (loss_i * mask).sum() / (loss_i.size(0) * max_completion_length)
-    else:
-        raise ValueError(f"Unknown loss type: {loss_type}")
-
-    with torch.inference_mode():
-        completion_length = mask.sum().float().mean()
-        mean_kl = (kl_i * mask).sum() / mask.sum().clamp(min=1.0)
-        mean_kl = mean_kl.mean()
-
-    return loss, completion_length, mean_kl, loss_i, kl_i, new_lp, ref_lp, old_lp
-
-def test_grpo_loss():
-    # 设置随机种子
-    torch.manual_seed(0)
-
-    # 配置参数
-    BL = 1024   # 总 token 数
-    V = 512        # 词汇表大小
-    temperature = 2.0
-    beta = 0.1
-    epsilon_low = 0.2
-    epsilon_high = 0.2
-    loss_type = "grpo"
-    logit_scale_multiply = 0.5
-    logit_scale_divide = 2.0
-    logit_softcapping = 10.0
-
-    # 构造输入数据
-    new_logits = torch.randn((BL, V), device='cuda', requires_grad=True)
-    ref_logits = torch.randn((BL, V), device='cuda')
-    old_logits = torch.randn((BL, V), device='cuda')
-    input_ids = torch.randint(0, V, (BL,), device='cuda')
-    advantages = torch.randn((BL,), device='cuda')
-    mask = torch.randint(0, 2, (BL,), device='cuda').bool()
-
-    # PyTorch 计算
-    loss_pt, completion_pt, mean_kl_pt, loss_i_pt, kl_i_pt, new_lp_pt, ref_lp_pt, old_lp_pt = grpo_compute_loss_torch(
-        new_logits, ref_logits, old_logits, input_ids, advantages, mask,
-        beta=beta, loss_type=loss_type,
-        epsilon_low=epsilon_low, epsilon_high=epsilon_high,
-        temperature=temperature,
-        logit_scale_multiply=logit_scale_multiply,
-        logit_scale_divide=logit_scale_divide,
-        logit_softcapping=logit_softcapping
-    )
-
-    # Triton 计算
-    loss_tr, completion_tr, mean_kl_tr, loss_i_tr, kl_i_tr = grpo_loss_triton(
-        new_logits, ref_logits, old_logits, input_ids, advantages, mask,
-        beta=beta, loss_type=loss_type,
-        epsilon_low=epsilon_low, epsilon_high=epsilon_high,
-        temperature=temperature,
-        logit_scale_multiply=logit_scale_multiply,
-        logit_scale_divide=logit_scale_divide,
-        logit_softcapping=logit_softcapping
-    )
-
-    # ----------------------------
-    # 比较输出
-    # ----------------------------
-    print("Loss (Torch):", loss_pt.item())
-    print("Loss (Triton):", loss_tr.item())
-    assert torch.allclose(loss_pt, loss_tr, atol=1e-3, rtol=1e-3), "Loss 不一致"
-
-    print("Mean KL (Torch):", mean_kl_pt.item())
-    print("Mean KL (Triton):", mean_kl_tr.item())
-    assert torch.allclose(mean_kl_pt, mean_kl_tr, atol=1e-3, rtol=1e-3), "Mean KL 不一致"
-
-    print("Completion Length (Torch):", completion_pt.item())
-    print("Completion Length (Triton):", completion_tr.item())
-    assert torch.allclose(completion_pt, completion_tr, atol=1e-3, rtol=1e-3), "Completion Length 不一致"
+class TestGRPOFunctionality(unittest.TestCase):
     
-    float_mask = mask.to(torch.float32)
-    assert torch.allclose(loss_i_pt * float_mask, loss_i_tr, atol=1e-3, rtol=1e-3), "Masked Loss_i 不一致"
+    def setUp(self):
+      
+        torch.manual_seed(42)
+        self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        if self.device == 'cpu':
+            self.skipTest("CUDA is not available, skipping Triton tests.")
 
-    # 对 kl_i 做同样的操作
-    assert torch.allclose(kl_i_pt * float_mask, kl_i_tr, atol=1e-3, rtol=1e-3), "Masked KL_i 不一致"
+    def _run_and_compare(self, BL, V, dtype, **kwargs):
+        
+       
+        new_logits = torch.randn((BL, V), device=self.device, dtype=dtype)
+        ref_logits = torch.randn((BL, V), device=self.device, dtype=dtype)
+        old_logits = torch.randn((BL, V), device=self.device, dtype=dtype)
+        input_ids = torch.randint(0, V, (BL,), device=self.device)
+        advantages = torch.randn((BL,), device=self.device, dtype=dtype)
+        mask = torch.randint(0, 2, (BL,), device=self.device).bool()
 
-    print("✅ 数值一致性验证通过！")
+       
+        loss_pt, comp_pt, kl_pt, loss_i_pt, kl_i_pt = grpo_compute_loss_torch(
+            new_logits, ref_logits, old_logits, input_ids, advantages, mask, **kwargs
+        )
+
+       
+        loss_tr, comp_tr, kl_tr, loss_i_tr, kl_i_tr = grpo_loss_triton(
+            new_logits, ref_logits, old_logits, input_ids, advantages, mask, **kwargs
+        )
+        
+    
+        atol = 1e-2 if dtype == torch.float16 else 1e-5
+        rtol = 1e-2 if dtype == torch.float16 else 1e-5
+
+        self.assertTrue(torch.allclose(loss_pt, loss_tr, atol=atol, rtol=rtol), "Aggregated Loss mismatch")
+        self.assertTrue(torch.allclose(kl_pt, kl_tr, atol=atol, rtol=rtol), "Mean KL mismatch")
+        self.assertTrue(torch.allclose(comp_pt, comp_tr), "Completion Length mismatch")
+        self.assertTrue(torch.allclose(loss_i_pt, loss_i_tr, atol=atol, rtol=rtol), "Per-token Loss mismatch")
+        self.assertTrue(torch.allclose(kl_i_pt, kl_i_tr, atol=atol, rtol=rtol), "Per-token KL mismatch")
+
+    def test_base_case_fp32(self):
+      
+        print("\nRunning: test_base_case_fp32")
+        self._run_and_compare(BL=1024, V=2048, dtype=torch.float32, delta=5.0, beta=0.1, temperature=1.0)
+
+    def test_base_case_fp16(self):
+        
+        print("\nRunning: test_base_case_fp16")
+        self._run_and_compare(BL=1024, V=2048, dtype=torch.float16, delta=5.0, beta=0.1, temperature=1.0)
+        
+    def test_no_delta_clipping(self):
+       
+        print("\nRunning: test_no_delta_clipping")
+        self._run_and_compare(BL=512, V=1024, dtype=torch.float16, delta=None)
+
+    def test_zero_beta(self):
+        """测试 beta=0 的情况，即没有 KL 惩罚"""
+        print("\nRunning: test_zero_beta")
+        self._run_and_compare(BL=512, V=1024, dtype=torch.float16, beta=0.0)
+
+    def test_temperature_scaling(self):
+        """测试 temperature != 1.0 的情况"""
+        print("\nRunning: test_temperature_scaling")
+        self._run_and_compare(BL=512, V=1024, dtype=torch.float16, temperature=2.0)
+
+    def test_all_masked(self):
+        """边缘情况测试：所有 token 都被掩码"""
+        print("\nRunning: test_all_masked")
+        BL, V, dtype = 256, 512, torch.float16
+        new_logits = torch.randn((BL, V), device=self.device, dtype=dtype)
+        ref_logits = torch.randn((BL, V), device=self.device, dtype=dtype)
+        old_logits = torch.randn((BL, V), device=self.device, dtype=dtype)
+        input_ids = torch.randint(0, V, (BL,), device=self.device)
+        advantages = torch.randn((BL,), device=self.device, dtype=dtype)
+        mask = torch.zeros((BL,), device=self.device).bool() # 全 False 掩码
+
+        loss_pt, _, kl_pt, _, _ = grpo_compute_loss_torch(new_logits, ref_logits, old_logits, input_ids, advantages, mask)
+        loss_tr, _, kl_tr, _, _ = grpo_loss_triton(new_logits, ref_logits, old_logits, input_ids, advantages, mask)
+
+     
+        self.assertTrue(torch.allclose(loss_pt, torch.tensor(0.0, device=self.device)), "Torch loss should be 0 when all masked")
+        self.assertTrue(torch.allclose(loss_tr, torch.tensor(0.0, device=self.device)), "Triton loss should be 0 when all masked")
+        self.assertTrue(torch.allclose(kl_pt, torch.tensor(0.0, device=self.device)), "Torch KL should be 0 when all masked")
+        self.assertTrue(torch.allclose(kl_tr, torch.tensor(0.0, device=self.device)), "Triton KL should be 0 when all masked")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
add grpo_compute_loss_logits.py

python benchmark/grpo.py
```
Benchmarking with BL=16384, V=32768, dtype=torch.float16
------------------------------------------------------------
PyTorch implementation: 31.6510 ms
Triton implementation:  30.9161 ms
Speedup: 1.02x
------------------------------------------------------------
Benchmarking with BL=2048, V=32768, dtype=torch.float16
------------------------------------------------------------
PyTorch implementation: 4.1275 ms
Triton implementation:  4.0477 ms
Speedup: 1.02x
------------------------------------------------------------
Benchmarking with BL=2048, V=65536, dtype=torch.float16
------------------------------------------------------------
PyTorch implementation: 7.9679 ms
Triton implementation:  7.8841 ms
Speedup: 1.01x
```

python test/test_grpo_loss_logits.py
```
Running: test_all_masked
Running: test_base_case_fp16
Running: test_base_case_fp32
Running: test_no_delta_clipping
Running: test_temperature_scaling
Running: test_zero_beta
----------------------------------------------------------------------
Ran 6 tests in 0.960s
OK
```