### PR TITLE
Add new ops.

### DIFF
--- a/dlblas/kernels/ks_competition/triton/QY2026_Autumn_Foxxiaohuli_Task01ComputeContactProb_MetaX.py
+++ b/dlblas/kernels/ks_competition/triton/QY2026_Autumn_Foxxiaohuli_Task01ComputeContactProb_MetaX.py
@@ -1,0 +1,250 @@
+import torch
+import torch.nn as nn
+
+import triton
+import triton.language as tl
+
+
+def get_bin_centers(min_bin: float, max_bin: float, no_bins: int) -> torch.Tensor:
+    edges = torch.linspace(min_bin, max_bin, no_bins + 1)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    return centers
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_J": 8, "BLOCK_K_INNER": 32}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_J": 16, "BLOCK_K_INNER": 32}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_J": 32, "BLOCK_K_INNER": 32}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_J": 64, "BLOCK_K_INNER": 32}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_J": 32, "BLOCK_K_INNER": 64}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_J": 64, "BLOCK_K_INNER": 64}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_J": 32, "BLOCK_K_INNER": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_J": 64, "BLOCK_K_INNER": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_J": 64, "BLOCK_K_INNER": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_J": 128, "BLOCK_K_INNER": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_J": 128, "BLOCK_K_INNER": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_J": 32, "BLOCK_K_INNER": 32}, num_warps=2, num_stages=3),
+        triton.Config({"BLOCK_J": 64, "BLOCK_K_INNER": 32}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_J": 64, "BLOCK_K_INNER": 64}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_J": 128, "BLOCK_K_INNER": 32}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_J": 64, "BLOCK_K_INNER": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_J": 128, "BLOCK_K_INNER": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_J": 128, "BLOCK_K_INNER": 32}, num_warps=8, num_stages=3),
+    ],
+    key=["N0", "N1", "B", "_thres"],
+)
+@triton.jit
+def contact_prob_kernel(
+    logits_ptr,
+    out_ptr,
+    stride0,
+    stride1,
+    stride2,
+    out_stride0,
+    out_stride1,
+    N0,
+    N1,
+    B,
+    _thres,
+    BLOCK_J: tl.constexpr,
+    BLOCK_K_INNER: tl.constexpr,
+):
+    pid_i = tl.program_id(0)
+    pid_j_blk = tl.program_id(1)
+
+    offs_j = pid_j_blk * BLOCK_J + tl.arange(0, BLOCK_J)
+    mask_j = offs_j < N1
+
+    m_prev = tl.full((BLOCK_J,), float("-inf"), dtype=tl.float32)
+    d_prev = tl.zeros((BLOCK_J,), dtype=tl.float32)
+    n_prev = tl.zeros((BLOCK_J,), dtype=tl.float32)
+
+    for k_start in range(0, B, BLOCK_K_INNER):
+        offs_k = k_start + tl.arange(0, BLOCK_K_INNER)
+        mask_k = offs_k < B
+
+        ptrs = (
+            logits_ptr
+            + pid_i * stride0
+            + offs_j[:, None] * stride1
+            + offs_k[None, :] * stride2
+        )
+        mask = mask_j[:, None] & mask_k[None, :]
+        x = tl.load(ptrs, mask=mask, other=-float("inf")).to(tl.float32)
+
+        x_max = tl.max(x, axis=1)
+        x = x - x_max[:, None]
+        exp_x = tl.exp(x)
+        exp_x = tl.where(mask_j[:, None], exp_x, 0.0)
+
+        d_curr = tl.sum(exp_x, axis=1)
+        mask_thres = offs_k[None, :] < _thres
+        n_curr = tl.sum(tl.where(mask_thres, exp_x, 0.0), axis=1)
+
+        m_new = tl.maximum(m_prev, x_max)
+        delta = tl.where(
+            (m_prev == float("-inf")) | (m_new == float("-inf")),
+            0.0,
+            m_new - m_prev,
+        )
+        alpha = tl.exp(-delta)
+        delta_curr = m_new - x_max
+        alpha_curr = tl.exp(-delta_curr)
+
+        d_prev = d_curr * alpha_curr + d_prev * alpha
+        n_prev = n_curr * alpha_curr + n_prev * alpha
+        m_prev = m_new
+
+    final_delta = tl.where(
+        m_prev == float("-inf"),
+        0.0,
+        0.0 - m_prev,
+    )
+    rescale = tl.exp(final_delta)
+    n_prev = n_prev * rescale
+    d_prev = d_prev * rescale
+
+    denom_safe = tl.where(mask_j, d_prev, 1.0)
+    res = n_prev / denom_safe
+    res = tl.where(mask_j, res, 0.0)
+
+    out_ptrs = out_ptr + pid_i * out_stride0 + offs_j * out_stride1
+    tl.store(out_ptrs, res, mask=mask_j)
+
+
+def compute_contact_prob(
+    distogram_logits: torch.Tensor,
+    min_bin: float,
+    max_bin: float,
+    no_bins: int,
+    thres: float = 8.0,
+    precomputed_thres_idx: int = None,
+) -> torch.Tensor:
+    if precomputed_thres_idx is not None:
+        thres_idx = precomputed_thres_idx
+    else:
+        bins_cpu = get_bin_centers(min_bin, max_bin, no_bins)
+        thres_idx = int((bins_cpu < thres).sum().item())
+
+    N0, N1, B = distogram_logits.shape
+    dtype = distogram_logits.dtype
+    device = distogram_logits.device
+
+    if thres_idx <= 0:
+        return torch.zeros((N0, N1), dtype=dtype, device=device)
+    if thres_idx >= no_bins:
+        return torch.ones((N0, N1), dtype=dtype, device=device)
+
+    if distogram_logits.is_cuda:
+        out = torch.empty((N0, N1), device=device, dtype=dtype)
+
+        stride0, stride1, stride2 = distogram_logits.stride()
+        out_s0, out_s1 = out.stride()
+
+        grid = lambda meta: (N0, (N1 + meta["BLOCK_J"] - 1) // meta["BLOCK_J"])
+        contact_prob_kernel[grid](
+            distogram_logits,
+            out,
+            stride0,
+            stride1,
+            stride2,
+            out_s0,
+            out_s1,
+            N0,
+            N1,
+            B,
+            thres_idx,
+        )
+        return out
+
+    distogram_prob = torch.softmax(distogram_logits, dim=-1)
+    bins = get_bin_centers(min_bin, max_bin, no_bins).to(distogram_logits.device)
+    thres_idx_ref = int((bins < thres).sum().item())
+    return distogram_prob[..., :thres_idx_ref].sum(dim=-1)
+
+
+class Model(nn.Module):
+    def __init__(
+        self,
+        min_bin: float = 2.3125,
+        max_bin: float = 21.6875,
+        no_bins: int = 64,
+        thres: float = 8.0,
+    ):
+        super().__init__()
+        self.min_bin = float(min_bin)
+        self.max_bin = float(max_bin)
+        self.no_bins = int(no_bins)
+        self.thres = float(thres)
+
+        bins = get_bin_centers(self.min_bin, self.max_bin, self.no_bins)
+        self._thres_idx = int((bins < self.thres).sum().item())
+        self._early_exit_zero = self._thres_idx <= 0
+        self._early_exit_one = self._thres_idx >= self.no_bins
+
+        self._out_cache = None
+
+    def forward(self, distogram_logits: torch.Tensor) -> torch.Tensor:
+        N0, N1, B = distogram_logits.shape
+        dtype = distogram_logits.dtype
+        device = distogram_logits.device
+
+        if self._early_exit_zero:
+            return torch.zeros((N0, N1), dtype=dtype, device=device)
+        if self._early_exit_one:
+            return torch.ones((N0, N1), dtype=dtype, device=device)
+
+        if (
+            self._out_cache is not None
+            and self._out_cache.shape == (N0, N1)
+            and self._out_cache.dtype == dtype
+            and self._out_cache.device == device
+        ):
+            out = self._out_cache
+        else:
+            out = torch.empty((N0, N1), device=device, dtype=dtype)
+            self._out_cache = out
+
+        stride0, stride1, stride2 = distogram_logits.stride()
+        out_s0, out_s1 = out.stride()
+
+        grid = lambda meta: (N0, (N1 + meta["BLOCK_J"] - 1) // meta["BLOCK_J"])
+        contact_prob_kernel[grid](
+            distogram_logits,
+            out,
+            stride0,
+            stride1,
+            stride2,
+            out_s0,
+            out_s1,
+            N0,
+            N1,
+            B,
+            self._thres_idx,
+        )
+        return out
+
+
+# ==========================================
+# Hyperparameters & Data Generation
+# ==========================================
+
+N_TOKEN = 256
+NO_BINS = 64
+MIN_BIN = 2.3125
+MAX_BIN = 21.6875
+THRES = 8.0
+
+
+def get_inputs():
+    device = "cuda"
+    torch.manual_seed(42)
+
+    distogram_logits = torch.randn(N_TOKEN, N_TOKEN, NO_BINS, device=device)
+
+    return [distogram_logits]
+
+
+def get_init_inputs():
+    return [MIN_BIN, MAX_BIN, NO_BINS, THRES]


### PR DESCRIPTION
使用自己写的测试脚本，对比原始参考实现（PyTorch）输出结果
====================================================================
01 ComputeContactProb
====================================================================

--- Correctness (multi-dtype) ---
  [PASS] Correctness(N=128, B=64)  max_abs_diff=1.490116e-07
  [PASS] Correctness(N=512, B=128)  max_abs_diff=1.490116e-07

--- Performance ---
   N_TOKEN  NO_BINS     Triton(ms)    PyTorch(ms)    Speedup
  ----------------------------------------------------------
        64       32         0.0290         0.2161      7.45x
        64       64         0.0293         0.2215      7.57x
       128       64         0.0322         0.2378      7.38x
       256       64         0.0417         0.2994      7.19x
       256      128         0.0529         0.3713      7.02x
       512       64         0.0768         0.5463      7.11x
       512      128         0.1188         0.8601      7.24x
      1024       64         0.2151         1.5335      7.13x