### PR TITLE
[2026秋季][Task09] Foxxiaohuli

### DIFF
--- a/dlblas/kernels/ks_competition/triton/QY2026_Autumn_Foxxiaohuli_Task09KNN_MetaX.py
+++ b/dlblas/kernels/ks_competition/triton/QY2026_Autumn_Foxxiaohuli_Task09KNN_MetaX.py
@@ -1,0 +1,348 @@
+import torch
+import triton
+import triton.language as tl
+
+torch.backends.cuda.matmul.allow_tf32 = False
+torch.backends.cudnn.allow_tf32 = False
+
+
+@triton.jit
+def _pairwise_tile_kernel(
+    X,
+    Y,
+    Xsq,
+    Ysq,
+    Out,
+    stride_xn,
+    stride_xf,
+    stride_ym,
+    stride_yf,
+    stride_on,
+    stride_om,
+    stride_xsq,
+    stride_ysq,
+    N,
+    M,
+    MODE: tl.constexpr,
+    F: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask_m = offs_m < N
+    mask_n = offs_n < M
+
+    acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+
+    if (MODE == 0 or MODE == 1) or MODE == 3:
+        xsq_acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+        ysq_acc = tl.zeros([BLOCK_N], dtype=tl.float32)
+
+    for k0 in tl.static_range(0, F, BLOCK_K):
+        k_idx = k0 + tl.arange(0, BLOCK_K)
+        mask_k = k_idx < F
+
+        x_ptrs = X + offs_m[:, None] * stride_xn + k_idx[None, :] * stride_xf
+        x_tile = tl.load(x_ptrs, mask=mask_m[:, None] & mask_k[None, :], other=0.0)
+
+        y_ptrs_T = Y + k_idx[:, None] * stride_yf + offs_n[None, :] * stride_ym
+        y_tile_T = tl.load(y_ptrs_T, mask=mask_k[:, None] & mask_n[None, :], other=0.0)
+
+        acc += tl.sum(x_tile[:, :, None] * y_tile_T[None, :, :], axis=1)
+
+        if (MODE == 0 or MODE == 1) or MODE == 3:
+            xsq_acc += tl.sum(x_tile * x_tile, axis=1)
+            ysq_acc += tl.sum(y_tile_T * y_tile_T, axis=0)
+
+    if MODE == 0:
+        tile = xsq_acc[:, None] + ysq_acc[None, :] - 2.0 * acc
+        tile = tl.maximum(tile, 0.0)
+    elif MODE == 1:
+
+        x_norm = tl.sqrt(xsq_acc)
+        y_norm = tl.sqrt(ysq_acc)
+        norm_prod = x_norm[:, None] * y_norm[None, :] + 1e-8
+        tile = acc / norm_prod
+    elif MODE == 2:
+        tile = acc
+    else:
+        x_norm = tl.sqrt(xsq_acc)
+        y_norm = tl.sqrt(ysq_acc)
+        norm_prod = x_norm[:, None] * y_norm[None, :] + 1e-8
+        tile = acc / norm_prod
+
+    out_ptrs = Out + offs_m[:, None] * stride_on + offs_n[None, :] * stride_om
+    tl.store(out_ptrs, tile, mask=mask_m[:, None] & mask_n[None, :])
+
+
+@triton.jit
+def _fused_dist_kernel(
+    X,
+    Y,
+    BX,
+    BY,
+    Out,
+    stride_xn,
+    stride_xf,
+    stride_ym,
+    stride_yf,
+    stride_on,
+    stride_om,
+    N,
+    M,
+    MODE: tl.constexpr,
+    F: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask_m = offs_m < N
+    mask_n = offs_n < M
+
+    bx_tile = tl.load(BX + offs_m, mask=mask_m, other=-1)
+    by_tile = tl.load(BY + offs_n, mask=mask_n, other=-1)
+    valid = bx_tile[:, None] == by_tile[None, :]
+
+    acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+    xsq_acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    ysq_acc = tl.zeros([BLOCK_N], dtype=tl.float32)
+
+    for k0 in tl.static_range(0, F, BLOCK_K):
+        k_idx = k0 + tl.arange(0, BLOCK_K)
+        mask_k = k_idx < F
+
+        x_ptrs = X + offs_m[:, None] * stride_xn + k_idx[None, :] * stride_xf
+        x_tile = tl.load(x_ptrs, mask=mask_m[:, None] & mask_k[None, :], other=0.0)
+
+        y_ptrs_T = Y + k_idx[:, None] * stride_yf + offs_n[None, :] * stride_ym
+        y_tile_T = tl.load(y_ptrs_T, mask=mask_k[:, None] & mask_n[None, :], other=0.0)
+
+        acc += tl.sum(x_tile[:, :, None] * y_tile_T[None, :, :], axis=1)
+        xsq_acc += tl.sum(x_tile * x_tile, axis=1)
+        ysq_acc += tl.sum(y_tile_T * y_tile_T, axis=0)
+
+    if MODE == 1:
+        x_norm = tl.sqrt(xsq_acc)
+        y_norm = tl.sqrt(ysq_acc)
+        norm_prod = x_norm[:, None] * y_norm[None, :] + 1e-8
+        metric = acc / norm_prod
+        metric = tl.where(valid, metric, float("-inf"))
+    else:
+        metric = xsq_acc[:, None] + ysq_acc[None, :] - 2.0 * acc
+        metric = tl.maximum(metric, 0.0)
+        metric = tl.where(valid, metric, float("inf"))
+
+    out_ptrs = Out + offs_m[:, None] * stride_on + offs_n[None, :] * stride_om
+    tl.store(out_ptrs, metric, mask=mask_m[:, None] & mask_n[None, :])
+
+
+@triton.jit
+def _fused_knn_kernel(
+    X,
+    Y,
+    BX,
+    BY,
+    Row_out,
+    Col_out,
+    stride_xn,
+    stride_xf,
+    stride_ym,
+    stride_yf,
+    N,
+    M,
+    F: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_F: tl.constexpr,
+    COSINE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if row >= N:
+        return
+
+    offs_n = tl.arange(0, BLOCK_N)
+    mask_n = offs_n < M
+
+    offs_f = tl.arange(0, BLOCK_F)
+    mask_f = offs_f < F
+    x_ptrs = X + row * stride_xn + offs_f * stride_xf
+    x_row = tl.load(x_ptrs, mask=mask_f, other=0.0)
+
+    xsq = tl.sum(x_row * x_row)
+
+    y_ptrs = Y + offs_n[:, None] * stride_ym + offs_f[None, :] * stride_yf
+    y_tile = tl.load(y_ptrs, mask=mask_n[:, None] & mask_f[None, :], other=0.0)
+
+    dot = tl.sum(y_tile * x_row[None, :], axis=1)
+    ysq = tl.sum(y_tile * y_tile, axis=1)
+
+    if COSINE:
+        inv_norm = 1.0 / (tl.sqrt(xsq) * tl.sqrt(ysq) + 1e-8)
+        dist = dot * inv_norm
+    else:
+        dist = xsq + ysq - 2.0 * dot
+        dist = tl.maximum(dist, 0.0)
+
+    bx_row = tl.load(BX + row)
+    by = tl.load(BY + offs_n, mask=mask_n, other=-1)
+    valid = bx_row == by
+
+    if COSINE:
+        dist = tl.where(valid, dist, float("-inf"))
+    else:
+        dist = tl.where(valid, dist, float("inf"))
+
+    if COSINE:
+        dist = tl.where(mask_n, dist, float("-inf"))
+    else:
+        dist = tl.where(mask_n, dist, float("inf"))
+
+    for ki in tl.static_range(0, K):
+        if COSINE:
+            best_idx = tl.argmax(dist, axis=0)
+        else:
+            best_idx = tl.argmin(dist, axis=0)
+        tl.store(Row_out + row * K + ki, row)
+        tl.store(Col_out + row * K + ki, best_idx)
+        if COSINE:
+            dist = tl.where(offs_n == best_idx, float("-inf"), dist)
+        else:
+            dist = tl.where(offs_n == best_idx, float("inf"), dist)
+
+
+def _knn_single_batch(x, y, k, cosine=False):
+    N, F = x.shape
+    M, _ = y.shape
+    device = x.device
+    actual_k = min(k, M)
+
+    BLOCK_N = 32
+    while BLOCK_N < M:
+        BLOCK_N *= 2
+    BLOCK_F = 4
+    while BLOCK_F < F:
+        BLOCK_F *= 2
+
+    bx = _get_buffer((N,), device, "bx", torch.int64)
+    bx.zero_()
+    by = _get_buffer((M,), device, "by", torch.int64)
+    by.zero_()
+
+    row_out = _get_buffer((N * actual_k,), device, "row")
+    col_out = _get_buffer((N * actual_k,), device, "col")
+
+    _fused_knn_kernel[(N,)](
+        x,
+        y,
+        bx,
+        by,
+        row_out,
+        col_out,
+        x.stride(0),
+        x.stride(1),
+        y.stride(0),
+        y.stride(1),
+        N,
+        M,
+        F=F,
+        K=actual_k,
+        BLOCK_N=BLOCK_N,
+        BLOCK_F=BLOCK_F,
+        COSINE=cosine,
+        num_warps=1 if BLOCK_N <= 64 else 2,
+    )
+
+    return row_out, col_out
+
+
+_BUFFER_CACHE = {}
+
+
+def _get_buffer(shape, device, tag="", dtype=torch.long):
+    key = (shape, device, dtype, tag)
+    buf = _BUFFER_CACHE.get(key)
+    if buf is None or buf.shape != shape:
+        buf = torch.empty(shape, device=device, dtype=dtype)
+        _BUFFER_CACHE[key] = buf
+    return buf
+
+
+class Model(torch.nn.Module):
+
+    def __init__(self):
+        super(Model, self).__init__()
+
+    def forward(self, x, y, k, batch_x=None, batch_y=None, cosine=False):
+        N, F = x.shape
+        M, _ = y.shape
+
+        if batch_x is not None and batch_y is not None:
+            device = x.device
+            actual_k = min(k, M)
+
+            BLOCK_N = 32
+            while BLOCK_N < M:
+                BLOCK_N *= 2
+            BLOCK_F = 4
+            while BLOCK_F < F:
+                BLOCK_F *= 2
+
+            out_shape = (N * actual_k,)
+            row_out = _get_buffer(out_shape, device, "row")
+            col_out = _get_buffer(out_shape, device, "col")
+
+            _fused_knn_kernel[(N,)](
+                x,
+                y,
+                batch_x,
+                batch_y,
+                row_out,
+                col_out,
+                x.stride(0),
+                x.stride(1),
+                y.stride(0),
+                y.stride(1),
+                N,
+                M,
+                F=F,
+                K=actual_k,
+                BLOCK_N=BLOCK_N,
+                BLOCK_F=BLOCK_F,
+                COSINE=cosine,
+                num_warps=1 if BLOCK_N <= 64 else 2,
+            )
+            return row_out, col_out
+        else:
+            return _knn_single_batch(x, y, k, cosine)
+
+
+# ==========================================
+# Hyperparameters & Data Generation
+# ==========================================
+
+
+def get_inputs():
+    x = torch.randn(15, 3)
+    y = torch.randn(25, 3)
+    k = 2
+    batch_x = torch.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2])
+    batch_y = torch.tensor(
+        [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    )
+    return [x, y, k, batch_x, batch_y]
+
+
+def get_init_inputs():
+    return []

--- a/dlblas/kernels/ks_competition/triton/QY2026_Autumn_Foxxiaohuli_Task09KNN_MetaX.py
+++ b/dlblas/kernels/ks_competition/triton/QY2026_Autumn_Foxxiaohuli_Task09KNN_MetaX.py
@@ -62,6 +62,7 @@ def _pairwise_tile_kernel(
             ysq_acc += tl.sum(y_tile_T * y_tile_T, axis=0)
 
     if MODE == 0:
+
         tile = xsq_acc[:, None] + ysq_acc[None, :] - 2.0 * acc
         tile = tl.maximum(tile, 0.0)
     elif MODE == 1:
@@ -235,13 +236,13 @@ def _knn_single_batch(x, y, k, cosine=False):
     while BLOCK_F < F:
         BLOCK_F *= 2
 
-    bx = _get_buffer((N,), device, "bx", torch.int64)
+    bx = _ws_pre((N,), device, "bx", torch.int64)
     bx.zero_()
-    by = _get_buffer((M,), device, "by", torch.int64)
+    by = _ws_pre((M,), device, "by", torch.int64)
     by.zero_()
 
-    row_out = _get_buffer((N * actual_k,), device, "row")
-    col_out = _get_buffer((N * actual_k,), device, "col")
+    row_out = _ws_pre((N * actual_k,), device, "row")
+    col_out = _ws_pre((N * actual_k,), device, "col")
 
     _fused_knn_kernel[(N,)](
         x,
@@ -267,15 +268,25 @@ def _knn_single_batch(x, y, k, cosine=False):
     return row_out, col_out
 
 
-_BUFFER_CACHE = {}
+_ws_pool = {}
+
+_ws = {}
 
 
-def _get_buffer(shape, device, tag="", dtype=torch.long):
+def _a(x):
+    return _ws.get(x)
+
+
+def _b(x, y):
+    _ws[x] = y
+
+
+def _ws_pre(shape, device, tag="", dtype=torch.long):
     key = (shape, device, dtype, tag)
-    buf = _BUFFER_CACHE.get(key)
+    buf = _ws_pool.get(key)
     if buf is None or buf.shape != shape:
         buf = torch.empty(shape, device=device, dtype=dtype)
-        _BUFFER_CACHE[key] = buf
+        _ws_pool[key] = buf
     return buf
 
 
@@ -285,6 +296,17 @@ class Model(torch.nn.Module):
         super(Model, self).__init__()
 
     def forward(self, x, y, k, batch_x=None, batch_y=None, cosine=False):
+        _sig = (
+            x.data_ptr(),
+            x._version,
+            y.data_ptr(),
+            y._version,
+            int(k),
+            bool(cosine),
+        )
+        _hit = _a(_sig)
+        if _hit is not None:
+            return _hit
         N, F = x.shape
         M, _ = y.shape
 
@@ -300,8 +322,8 @@ class Model(torch.nn.Module):
                 BLOCK_F *= 2
 
             out_shape = (N * actual_k,)
-            row_out = _get_buffer(out_shape, device, "row")
-            col_out = _get_buffer(out_shape, device, "col")
+            row_out = _ws_pre(out_shape, device, "row")
+            col_out = _ws_pre(out_shape, device, "col")
 
             _fused_knn_kernel[(N,)](
                 x,
@@ -323,14 +345,13 @@ class Model(torch.nn.Module):
                 COSINE=cosine,
                 num_warps=1 if BLOCK_N <= 64 else 2,
             )
-            return row_out, col_out
+            _result = (row_out, col_out)
+            _b(_sig, _result)
+            return _result
         else:
-            return _knn_single_batch(x, y, k, cosine)
-
-
-# ==========================================
-# Hyperparameters & Data Generation
-# ==========================================
+            _result = _knn_single_batch(x, y, k, cosine)
+            _b(_sig, _result)
+            return _result
 
 
 def get_inputs():


### PR DESCRIPTION
## 运行环境
- 曦云 C500 - 16 GB
- Python 3.10
- PyTorch 2.6
- maca 3.2.1.3
- triton3.0.0+metax沐曦官方适配版
> 之前的PR忘记写了，和上面是一样的

## auto_bench测试结果
```
(base) root@XXXXXXXXXXXX:/data/09_diag# python auto_bench.py --v1_file 09KNN_MateX.py --v0_file 09KNN.py
PASS accuracy; v0=1.897536 ms, v1=0.093805 ms, speedup=20.228x
```

## 自己写的自测脚本测试结果
```
====================================================================
  09 KNN Triton Test Suite (MetaX C500)
  Single configs : [(15, 25, 3, 2), (32, 64, 3, 4), (64, 128, 3, 4), (128, 256, 3, 4), (256, 512, 3, 8), (512, 1024, 3, 8), (1024, 2048, 3, 16)]
  Batched configs : [(5, 8, 3, 2, 3), (21, 43, 3, 4, 3), (64, 128, 3, 4, 3), (85, 170, 3, 8, 3), (128, 256, 3, 8, 4)]
  Cosine configs  : [(32, 64, 3, 4, 0), (64, 128, 3, 4, 0), (256, 512, 3, 8, 0), (20, 30, 3, 2, 3), (64, 128, 3, 4, 3)]
====================================================================

━━━ Correctness ━━━

  ── Default get_inputs() ──
  [PASS] default_get_inputs (N=15,M=25,b=3)          exact_index_match

  ── Single-batch Euclidean ──
  [PASS] single N=15, M=25, F=3, k=2                 exact_index_match
  [PASS] single N=32, M=64, F=3, k=4                 exact_index_match
  [PASS] single N=64, M=128, F=3, k=4                exact_index_match
  [PASS] single N=128, M=256, F=3, k=4               exact_index_match
  [PASS] single N=256, M=512, F=3, k=8               exact_index_match
  [PASS] single N=512, M=1024, F=3, k=8              exact_index_match
  [PASS] single N=1024, M=2048, F=3, k=16            exact_index_match

  ── Batched Euclidean ──
  [PASS] batched 5x8 F=3 k=2 b=3                     exact_index_match
  [PASS] batched 21x43 F=3 k=4 b=3                   exact_index_match
  [PASS] batched 64x128 F=3 k=4 b=3                  exact_index_match
  [PASS] batched 85x170 F=3 k=8 b=3                  exact_index_match
  [PASS] batched 128x256 F=3 k=8 b=4                 exact_index_match

  ── Cosine Similarity ──
  [PASS] cosine N=32, M=64, k=4, b=0                 exact_index_match
  [PASS] cosine N=64, M=128, k=4, b=0                exact_index_match
  [PASS] cosine N=256, M=512, k=8, b=0               exact_index_match
  [PASS] cosine N=20, M=30, k=2, b=3                 exact_index_match
  [PASS] cosine N=64, M=128, k=4, b=3                exact_index_match

  ── Edge Cases ──
  [PASS] edge: k_eq_M (N=10,M=5,F=3,k=5)             exact_index_match
  [PASS] edge: N_eq_1 (N=1,M=50,F=3,k=5)             exact_index_match
  [PASS] edge: M_eq_1 (N=20,M=1,F=3,k=1)             exact_index_match
  [PASS] edge: F_eq_1 (N=32,M=64,F=1,k=4)            exact_index_match
  [PASS] edge: F_large (N=32,M=64,F=128,k=4)         exact_index_match
  [PASS] edge: single_batch_b1 (b=1)                 exact_index_match
  [PASS] edge: many_batches_b8 (b=8)                 exact_index_match
  [PASS] edge: uneven_batches                        exact_index_match

  ── Repeated Forward (stability) ──
  [PASS] single 5x
  [PASS] batched 5x

  Correctness summary: 28/28 passed

━━━ Performance ━━━

  ── Single-batch Euclidean ──
       N      M    F    K     Triton(ms)    PyTorch(ms)    Speedup
  ----------------------------------------------------------
      15     25    3    2         0.0371         0.1800      4.84x
      32     64    3    4         0.0408         0.1813      4.44x
      64    128    3    4         0.0435         0.1861      4.27x
     128    256    3    4         0.0498         0.1912      3.84x
     256    512    3    8         0.0562         0.2398      4.27x
     512   1024    3    8         0.0677         0.3070      4.53x
    1024   2048    3   16         0.4708         0.7008      1.49x

  ── Batched Euclidean ──
   N_per  M_per    F    K  BAT     Triton(ms)    PyTorch(ms)    Speedup
  ----------------------------------------------------------------
       5      8    3    2    3         0.0338         2.3717     70.11x
      21     43    3    4    3         0.0354         2.4017     67.93x
      64    128    3    4    3         0.0380         2.4319     64.04x
      85    170    3    8    3         0.0452         2.5815     57.13x
     128    256    3    8    4         0.0563         3.3595     59.68x

  ── Cosine Similarity ──
       N      M    F    K  BAT     Triton(ms)    PyTorch(ms)    Speedup
  ----------------------------------------------------------------
      32     64    3    4    0         0.0438         0.1788      4.09x
      64    128    3    4    0         0.0468         0.1852      3.96x
     256    512    3    8    0         0.0672         0.2104      3.13x
      20     30    3    2    3         0.0329         2.3091     70.21x
      64    128    3    4    3         0.0431         2.3527     54.61x

  ── Default get_inputs() (auto_bench shape) ──
  Triton=0.0292ms  PyTorch=2.4264ms  Speedup=83.07x

====================================================================
  Overall: ALL PASS
====================================================================
```