### PR TITLE
Fix int32 overflow in permute_bwd_kernel row offsets

### DIFF
--- a/dlblas/kernels/permute/moe_triton_kernels.py
+++ b/dlblas/kernels/permute/moe_triton_kernels.py
@@ -143,7 +143,8 @@ def permute_bwd_kernel(
     num_topK: tl.constexpr,
     BLOCK_SIZE_COLS: tl.constexpr,
 ):
-    pid_m = tl.program_id(axis=0)
+    # 64 位行偏移：pid_m * num_cols 和 perm_row * num_cols 在 int32 下会溢出
+    pid_m = tl.program_id(axis=0).to(tl.int64)
 
     for col_block_start in range(0, tl.cdiv(num_cols, BLOCK_SIZE_COLS)):
         col_offsets = col_block_start * BLOCK_SIZE_COLS + tl.arange(0, BLOCK_SIZE_COLS)
@@ -155,7 +156,7 @@ def permute_bwd_kernel(
         # tl.static_range 确保这个循环在编译时展开，没有运行时开销
         for k in tl.static_range(num_topK):
             # 加载需要 gather 的行索引
-            perm_row = tl.load(inv_idx_ptr + pid_m * num_topK + k)
+            perm_row = tl.load(inv_idx_ptr + pid_m * num_topK + k).to(tl.int64)
             is_valid = perm_row >= 0
 
             vals = tl.load(go_ptr + perm_row * num_cols + col_offsets, 

--- a/tests/kernels/test_moe_permute_bwd.py
+++ b/tests/kernels/test_moe_permute_bwd.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025, DeepLink.
+import pytest
+import torch
+
+from dlblas.kernels.permute.moe_triton_kernels import moe_permute_topk_bwd_op
+from dlblas.utils.device_utils import infer_device
+
+device = infer_device()
+
+
+def _reference_rows(go, pos, tokens, num_topK):
+    # same accumulation order and dtype as permute_bwd_kernel: bf16, k-sequential
+    out = []
+    for t in tokens:
+        acc = torch.zeros(go.shape[1], device=go.device, dtype=go.dtype)
+        for k in range(num_topK):
+            acc = acc + go[pos[t, k]]
+        out.append(acc)
+    return torch.stack(out)
+
+
+def _position_table(sorted_row_id, num_tokens, num_topK):
+    # pos[t, k] = permuted row that holds slot (t, k)
+    num_elements = num_tokens * num_topK
+    pos = torch.empty(num_elements, dtype=torch.long, device=sorted_row_id.device)
+    pos[sorted_row_id] = torch.arange(num_elements, device=sorted_row_id.device)
+    return pos.view(num_tokens, num_topK)
+
+
+@pytest.mark.parametrize("num_tokens, num_topK, hidden", [
+    (128, 8, 512),
+    (1000, 4, 1000),
+])
+def test_moe_permute_topk_bwd(num_tokens, num_topK, hidden):
+    torch.manual_seed(0)
+    num_elements = num_tokens * num_topK
+    go = torch.randn(num_elements, hidden, device=device, dtype=torch.bfloat16)
+    sorted_row_id = torch.randperm(num_elements, device=device)
+
+    act_grad = moe_permute_topk_bwd_op(go, sorted_row_id, (num_tokens, hidden), num_topK)
+
+    pos = _position_table(sorted_row_id, num_tokens, num_topK)
+    ref = _reference_rows(go, pos, range(num_tokens), num_topK)
+    assert torch.equal(act_grad, ref)
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_properties(0).total_memory < 10 * 2**30,
+    reason="needs a >2**31-element gradient buffer (~5 GB)",
+)
+def test_moe_permute_topk_bwd_large_offsets():
+    # row offsets must be computed in 64-bit: perm_row * num_cols exceeds
+    # 2**31 once the permuted gradient buffer passes 2**31 elements
+    # (hidden=7168, topK=8 reaches that at ~37.4k tokens)
+    torch.manual_seed(0)
+    num_tokens, num_topK, hidden = 37600, 8, 7168
+    num_elements = num_tokens * num_topK
+    assert num_elements * hidden > 2**31
+    wrap_row = 2**31 // hidden
+
+    go = torch.randn(num_elements, hidden, device=device, dtype=torch.bfloat16)
+    sorted_row_id = torch.randperm(num_elements, device=device)
+
+    act_grad = moe_permute_topk_bwd_op(go, sorted_row_id, (num_tokens, hidden), num_topK)
+    torch.cuda.synchronize()
+
+    # spot-check tokens that gather rows past the wrap threshold, plus controls
+    pos = _position_table(sorted_row_id, num_tokens, num_topK)
+    above = (pos >= wrap_row).any(dim=1).nonzero().flatten()
+    sample = above[:16].tolist() + [0, 1, num_tokens // 2]
+    ref = _reference_rows(go, pos, sample, num_topK)
+    assert torch.equal(act_grad[sample], ref)


### PR DESCRIPTION
## Description

`permute_bwd_kernel` loads `perm_row` from the int32 `inv_idx` table and multiplies it by `num_cols` in 32-bit arithmetic; the product is widened to 64-bit only afterwards, so once `perm_row * num_cols` reaches 2^31 the offset wraps negative and the kernel reads far below the gradient buffer. The store address (`pid_m * num_cols`) wraps the same way at `num_topK`-times-larger row counts. With `hidden = 7168` and `topK = 8` the read wrap is reached at ~37.4k tokens: `moe_permute_topk_bwd_op` crashes with an illegal memory access (or silently returns garbage if the wrapped address is mapped).

Changes:

- Widen `pid_m` and the loaded `perm_row` to `tl.int64` before any scaling, so every row offset in the kernel is computed in 64-bit. This is the same spelling TransformerEngine's `_unpermute_kernel` uses, and the same fix class as vllm-project/vllm#41617.

Measured on an L40S: at `tokens=38000, topK=8, hidden=7168` (bf16, 304000-row buffer, 4.4 GB) the op crashes with an illegal memory access before this PR and completes after it, with sampled output rows bit-identical to a reference computed in the kernel's accumulation order. Overhead of the 64-bit addressing, full-op `do_bench` at `tokens=8192, topK=8, hidden=7168` (no wrap, interleaved runs x3): 1.5663–1.5672 ms before, 1.5702–1.5706 ms after (~+0.2%).

## Tests

`tests/kernels/permute/` has no pytest coverage (its scripts are a standalone harness with a hard-coded device). Added `tests/kernels/test_moe_permute_bwd.py`: two small exact-correctness tests for `moe_permute_topk_bwd_op` against a reference with the kernel's accumulation order, plus `test_moe_permute_topk_bwd_large_offsets`, which drives a >2^31-element gradient buffer (skipped on GPUs with <10 GB memory). Reverting the kernel change alone makes the large-offsets test fail with the illegal memory access while the small tests still pass; all three pass with the fix.

Fixes #171

## Environment

- based on DLBlas `main` @ 9b5b3627
- NVIDIA L40S, driver CUDA 12.4
- torch 2.6.0+cu124, triton 3.2.0, Python 3.12
