### PR TITLE
fix(ks/auto-bench): make v0/v1 comparisons deterministic

### DIFF
--- a/benchmarks/ks/auto_bench.py
+++ b/benchmarks/ks/auto_bench.py
@@ -1,5 +1,6 @@
 import argparse
 import ast
+import contextlib
 import importlib.util
 import statistics
 import sys
@@ -52,6 +53,15 @@ def parse_args():
         "--full-traceback",
         action="store_true",
         help="Print full Python traceback for load/run failures.",
+    )
+    parser.add_argument(
+        "--math-sdpa",
+        action="store_true",
+        help=(
+            "Force PyTorch scaled-dot-product attention to its math backend. "
+            "Useful when an installed FlashAttention plugin is incompatible with "
+            "the current PyTorch/ROCm runtime."
+        ),
     )
     return parser.parse_args()
 
@@ -386,9 +396,14 @@ def build_case(v0_path: Path, v1_path: Path, seed: int):
         f"{v1_path}: get_init_inputs()",
     )
 
+    # Model constructors may initialise trainable parameters from the RNG.  Build
+    # both variants from the same RNG state so correctness compares equivalent
+    # weights rather than two unrelated random models.
+    set_seed(seed)
     model = call_with_context(
         lambda: model_cls(*v0_init_args), f"{v0_path}: Model(...)"
     )
+    set_seed(seed)
     model_new = call_with_context(
         lambda: model_new_cls(*v1_init_args), f"{v1_path}: ModelNew(...)"
     )
@@ -537,12 +552,22 @@ def compare_case(name, v0_path, v1_path, args):
     v1_inputs = _move_to_device(v1_inputs, target_device)
     v1_inputs = clone_value(v0_inputs)
 
-    v0_output = run_forward(model, v0_inputs, args.seed, f"{name}: v0")
-    v1_output = run_forward(model_new, v1_inputs, args.seed, f"{name}: v1")
-    compare_values(v0_output, v1_output, "output", args.atol, args.rtol)
+    # The context covers both correctness and timed calls.  This only changes
+    # PyTorch SDPA dispatch; custom Triton kernels remain the executed v1 path.
+    sdpa_context = (
+        torch.backends.cuda.sdp_kernel(
+            enable_flash=False, enable_math=True, enable_mem_efficient=False
+        )
+        if args.math_sdpa
+        else contextlib.nullcontext()
+    )
+    with sdpa_context:
+        v0_output = run_forward(model, v0_inputs, args.seed, f"{name}: v0")
+        v1_output = run_forward(model_new, v1_inputs, args.seed, f"{name}: v1")
+        compare_values(v0_output, v1_output, "output", args.atol, args.rtol)
 
-    v0_ms = time_forward(model, v0_inputs, args.seed, args.warmup, args.repeat)
-    v1_ms = time_forward(model_new, v1_inputs, args.seed, args.warmup, args.repeat)
+        v0_ms = time_forward(model, v0_inputs, args.seed, args.warmup, args.repeat)
+        v1_ms = time_forward(model_new, v1_inputs, args.seed, args.warmup, args.repeat)
     speedup = v0_ms / v1_ms if v1_ms > 0 else float("inf")
     return CaseResult(name=name, passed=True, v0_ms=v0_ms, v1_ms=v1_ms, speedup=speedup)
 

--- a/benchmarks/ks/auto_bench.py
+++ b/benchmarks/ks/auto_bench.py
@@ -510,21 +510,29 @@ def _move_to_device(value, device):
     return value
 
 
+def _move_model_to_device(model, device, description):
+    """Move a torch module's parameters and buffers to the target device."""
+    if not isinstance(model, torch.nn.Module):
+        return model
+    try:
+        return model.to(device)
+    except Exception as exc:
+        raise KsCompareError(
+            f"{description}: failed to move model to {device}: {exc}"
+        ) from exc
+
+
 def compare_case(name, v0_path, v1_path, args):
     model, model_new, v0_inputs, v1_inputs = build_case(v0_path, v1_path, args.seed)
 
     target_device = _detect_target_device(model, model_new, v0_inputs, v1_inputs)
-
     try:
         model_new.load_state_dict(model.state_dict())
     except Exception:
         pass
 
-    if hasattr(model, "to"):
-        model = model.to(target_device)
-    if hasattr(model_new, "to"):
-        model_new = model_new.to(target_device)
-
+    model = _move_model_to_device(model, target_device, f"{name}: v0")
+    model_new = _move_model_to_device(model_new, target_device, f"{name}: v1")
     v0_inputs = _move_to_device(v0_inputs, target_device)
     v1_inputs = _move_to_device(v1_inputs, target_device)
     v1_inputs = clone_value(v0_inputs)

--- a/benchmarks/ks/auto_bench.py
+++ b/benchmarks/ks/auto_bench.py
@@ -417,17 +417,12 @@ def build_case(v0_path: Path, v1_path: Path, seed: int):
         call_with_context(v0_get_inputs, f"{v0_path}: get_inputs()"),
         f"{v0_path}: get_inputs()",
     )
-    set_seed(seed)
-    v1_inputs = as_args(
-        call_with_context(v1_get_inputs, f"{v1_path}: get_inputs()"),
-        f"{v1_path}: get_inputs()",
-    )
-
-    if len(v0_inputs) != len(v1_inputs):
-        raise KsCompareError(
-            f"get_inputs argument count mismatch: {v0_path} returns {len(v0_inputs)} "
-            f"args, {v1_path} returns {len(v1_inputs)} args."
-        )
+    # v0/reference inputs are the canonical comparison data.  Generating a
+    # separate v1 input can yield different values even under the same seed
+    # when the files use different device RNGs (CPU vs CUDA).  Clone the
+    # canonical data instead; compare_case later moves both copies to the same
+    # accelerator before executing either implementation.
+    v1_inputs = clone_value(v0_inputs)
     return model, model_new, v0_inputs, v1_inputs
 
 

--- a/tests/benchmarks/test_ks_auto_bench.py
+++ b/tests/benchmarks/test_ks_auto_bench.py
@@ -1,4 +1,6 @@
 import importlib.util
+import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -43,6 +45,38 @@ class AutoBenchDeviceTests(unittest.TestCase):
             auto_bench._move_model_to_device(
                 BrokenModel(), torch.device("cpu"), "case: v1"
             )
+
+    def test_build_case_reseeds_parameterized_models(self):
+        source = textwrap.dedent(
+            """
+            import torch
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.weight = torch.nn.Parameter(torch.randn(4))
+
+                def forward(self):
+                    return self.weight
+
+            class ModelNew(Model):
+                pass
+
+            def get_init_inputs():
+                return []
+
+            def get_inputs():
+                return []
+            """
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            v0_path = Path(tmpdir) / "v0.py"
+            v1_path = Path(tmpdir) / "v1.py"
+            v0_path.write_text(source)
+            v1_path.write_text(source)
+            model, model_new, _, _ = auto_bench.build_case(v0_path, v1_path, 42)
+
+        self.assertTrue(torch.equal(model.weight, model_new.weight))
 
 
 if __name__ == "__main__":

--- a/tests/benchmarks/test_ks_auto_bench.py
+++ b/tests/benchmarks/test_ks_auto_bench.py
@@ -1,0 +1,49 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+import torch
+
+
+AUTO_BENCH_PATH = (
+    Path(__file__).parents[2] / "benchmarks" / "ks" / "auto_bench.py"
+)
+SPEC = importlib.util.spec_from_file_location("ks_auto_bench", AUTO_BENCH_PATH)
+auto_bench = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(auto_bench)
+
+
+class TrackingModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(1))
+        self.moves = []
+
+    def to(self, device):
+        self.moves.append(device)
+        return super().to(device)
+
+
+class AutoBenchDeviceTests(unittest.TestCase):
+    def test_move_model_to_device_moves_parameters(self):
+        model = TrackingModel()
+
+        result = auto_bench._move_model_to_device(model, torch.device("cpu"), "v0")
+
+        self.assertIs(result, model)
+        self.assertEqual(model.moves, [torch.device("cpu")])
+        self.assertEqual(model.weight.device.type, "cpu")
+
+    def test_move_model_to_device_wraps_failure(self):
+        class BrokenModel(torch.nn.Module):
+            def to(self, device):
+                raise RuntimeError("move failed")
+
+        with self.assertRaisesRegex(auto_bench.KsCompareError, "v1.*cpu.*move failed"):
+            auto_bench._move_model_to_device(
+                BrokenModel(), torch.device("cpu"), "case: v1"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/test_ks_auto_bench.py
+++ b/tests/benchmarks/test_ks_auto_bench.py
@@ -78,6 +78,45 @@ class AutoBenchDeviceTests(unittest.TestCase):
 
         self.assertTrue(torch.equal(model.weight, model_new.weight))
 
+    def test_build_case_clones_reference_inputs_for_v1(self):
+        v0_source = textwrap.dedent(
+            """
+            import torch
+
+            class Model(torch.nn.Module):
+                pass
+
+            def get_init_inputs():
+                return []
+
+            def get_inputs():
+                return [torch.tensor([3.0])]
+            """
+        )
+        v1_source = textwrap.dedent(
+            """
+            import torch
+
+            class ModelNew(torch.nn.Module):
+                pass
+
+            def get_init_inputs():
+                return []
+
+            def get_inputs():
+                return [torch.tensor([-1.0])]
+            """
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            v0_path = Path(tmpdir) / "v0.py"
+            v1_path = Path(tmpdir) / "v1.py"
+            v0_path.write_text(v0_source)
+            v1_path.write_text(v1_source)
+            _, _, v0_inputs, v1_inputs = auto_bench.build_case(v0_path, v1_path, 42)
+
+        self.assertTrue(torch.equal(v0_inputs[0], v1_inputs[0]))
+        self.assertNotEqual(v0_inputs[0].data_ptr(), v1_inputs[0].data_ptr())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- move both reference and optimized models to the selected accelerator with contextual errors
- reseed model construction for deterministic parameters and add the optional `--math-sdpa` comparison mode
- use reference `get_inputs()` as canonical data and deep-clone it for v1, avoiding CPU/device RNG mismatches
- add focused unit tests for model movement, deterministic initialization, and independent cloned inputs

## Context
This branch is rebased onto the current `DeepLink-org/DLBlas:main` and preserves the GCU support added by #170.

## Validation
- `python3.10 tests/benchmarks/test_ks_auto_bench.py`
- 4 tests passed in the Hygon DTK 26.04 / PyTorch 2.10 container
- `git diff --check origin/main..HEAD` passed
